### PR TITLE
Fix title page color related error with pdflatex

### DIFF
--- a/eisvogel.latex
+++ b/eisvogel.latex
@@ -501,7 +501,7 @@ $endif$
 \begin{flushleft}
 \noindent
 \\[-1em]
-\color[HTML]{$if(titlepage-text-color)$$titlepage-text-color$$else$5f5f5f$endif$}
+\color[HTML]{$if(titlepage-text-color)$$titlepage-text-color$$else$5F5F5F$endif$}
 \makebox[0pt][l]{\colorRule[$if(titlepage-rule-color)$$titlepage-rule-color$$else$435488$endif$]{1.3\textwidth}{$if(titlepage-rule-height)$$titlepage-rule-height$$else$4$endif$pt}}
 \par
 \noindent


### PR DESCRIPTION
This pull requests fixes a pdflatex crash when the title page is enabled.

I tried using the new title page feature today, but pdflatex on my Windows system at work crashed with the following error:

```
! Illegal unit of measure (pt inserted).
<to be read again>
                   f
l.323 \color[HTML]{5f5f5f}

?
! Emergency stop.
```

It seems that pdflatex (at least mine, i.e. pdfTeX 3.14159265-2.6-1.40.16) expects the HTML-Color value to be in uppercase characters. Thus I put the letters in the Hex-value to uppercase.

Here's some info on the specification for the color values:
https://tex.stackexchange.com/a/18010