### PR TITLE
Add setting for caption justifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ This template defines some new variables to control the appearance of the title 
 - `titlepage-rule-height` default=`4`
     
     the height of the rule on the top of the title page (in points)
+- `caption-justification` default=`raggedright`
+    
+    justification setting for captions (uses the `justification` parameter of the [caption](https://ctan.org/pkg/caption?lang=en) package)
 
 ## Examples
 

--- a/eisvogel.tex
+++ b/eisvogel.tex
@@ -470,7 +470,7 @@ $endif$
 % captions
 %
 \definecolor{caption-color}{HTML}{777777}
-\usepackage[font={stretch=1.2}, textfont={color=caption-color}, position=top, skip=4mm, labelfont=bf, singlelinecheck=false]{caption}
+\usepackage[font={stretch=1.2}, textfont={color=caption-color}, position=top, skip=4mm, labelfont=bf, singlelinecheck=false, justification=$if(caption-justification)$$caption-justification$$else$raggedright$endif$]{caption}
 \setcapindent{0em}
 \captionsetup[longtable]{position=above}
 


### PR DESCRIPTION
Allows setting the caption justification, as the default is to center
figures but left-align captions.