### PR TITLE
Fix alternating row colors in array/matrix.

### DIFF
--- a/eisvogel.tex
+++ b/eisvogel.tex
@@ -544,14 +544,15 @@ $if(tables)$
 \arrayrulecolor{table-rule-color}     % color of \toprule, \midrule, \bottomrule
 \setlength\heavyrulewidth{0.3ex}      % thickness of \toprule, \bottomrule
 \renewcommand{\arraystretch}{1.3}     % spacing (padding)
-\rowcolors{3}{}{table-row-color!100}  % row color
 
 % Reset rownum counter so that each table
 % starts with the same row colors.
 % https://tex.stackexchange.com/questions/170637/restarting-rowcolors
 \let\oldlongtable\longtable
 \let\endoldlongtable\endlongtable
-\renewenvironment{longtable}{\oldlongtable} {
+\renewenvironment{longtable}{
+\rowcolors{3}{}{table-row-color!100}  % row color
+\oldlongtable} {
 \endoldlongtable
 \global\rownum=0\relax}
 


### PR DESCRIPTION
When tables are used, the alternating row color effect also shows up in array/matrix environments in math mode, as shown in [before.pdf](https://github.com/Wandmalfarbe/pandoc-latex-template/files/2153134/before.pdf).
[Same file after the patch](https://github.com/Wandmalfarbe/pandoc-latex-template/files/2153136/after.pdf).