### PR TITLE
Add "toc-title" variable support

### DIFF
--- a/eisvogel.tex
+++ b/eisvogel.tex
@@ -719,6 +719,9 @@ $include-before$
 
 $endfor$
 $if(toc)$
+$if(toc-title)$
+\renewcommand*\contentsname{$toc-title$}
+$endif$
 $if(beamer)$
 \begin{frame}
 \tableofcontents[hideallsubsections]


### PR DESCRIPTION
We can change toc title by setting the `toc-title` variable

For example:

```markdown
---
title: doc title
toc: true
toc-title: Summary
---
```
