### PR TITLE
Fix custom-titlepage-example

### DIFF
--- a/examples/custom-titlepage/custom-titlepage.md
+++ b/examples/custom-titlepage/custom-titlepage.md
@@ -7,8 +7,8 @@ keywords: [Markdown, Example]
 subtitle: "Aesculeae domus vincemur et Veneris adsuetus lapsum"
 titlepage: true
 titlepage-color: "06386e"
-titlepage-text-color: "ffffff"
-titlepage-rule-color: "ffffff"
+titlepage-text-color: "FFFFFF"
+titlepage-rule-color: "FFFFFF"
 titlepage-rule-height: 1
 ...
 


### PR DESCRIPTION
custom-titlepage: change color from "ffffff" to "FFFFFF" to avoid LaTeX errors

Closes https://github.com/Wandmalfarbe/pandoc-latex-template/issues/54