### PR TITLE
Book: Distinguish even/odd pages in header with twoside

### DIFF
--- a/eisvogel.tex
+++ b/eisvogel.tex
@@ -647,12 +647,12 @@ $else$
 \pagestyle{fancy}
 \fancyhead{}
 \fancyfoot{}
-\lhead{$if(header-left)$$header-left$$else$$title$$endif$}
-\chead{$if(header-center)$$header-center$$else$$endif$}
-\rhead{$if(header-right)$$header-right$$else$$date$$endif$}
-\lfoot{$if(footer-left)$$footer-left$$else$$for(author)$$author$$sep$, $endfor$$endif$}
-\cfoot{$if(footer-center)$$footer-center$$else$$endif$}
-\rfoot{$if(footer-right)$$footer-right$$else$\thepage$endif$}
+\lhead[$if(header-right)$$header-right$$else$$date$$endif$]{$if(header-left)$$header-left$$else$$title$$endif$}
+\chead[$if(header-center)$$header-center$$else$$endif$]{$if(header-center)$$header-center$$else$$endif$}
+\rhead[$if(header-left)$$header-left$$else$$title$$endif$]{$if(header-right)$$header-right$$else$$date$$endif$}
+\lfoot[$if(footer-right)$$footer-right$$else$\thepage$endif$]{$if(footer-left)$$footer-left$$else$$for(author)$$author$$sep$, $endfor$$endif$}
+\cfoot[$if(footer-center)$$footer-center$$else$$endif$]{$if(footer-center)$$footer-center$$else$$endif$}
+\rfoot[$if(footer-left)$$footer-left$$else$$for(author)$$author$$sep$, $endfor$$endif$]{$if(footer-right)$$footer-right$$else$\thepage$endif$}
 \renewcommand{\headrulewidth}{0.4pt}
 \renewcommand{\footrulewidth}{0.4pt}
 $endif$


### PR DESCRIPTION
Extend definitions for `lhead` ... `rfoot` to pay attention to oneside or twoside mode, i.e. using `lhead[<even output>]{<odd output>}` ...

Closes  https://github.com/Wandmalfarbe/pandoc-latex-template/issues/56