### PR TITLE
add book option

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ This template defines some new variables to control the appearance of the title 
 - `footer-right` (defaults to the page number)
 	
 	the text on the right side of the footer
+- `book` (defaults to `false`)
+
+    typeset as book.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ pandoc example.md -o example.pdf --template eisvogel -V lang=de
 
 ### Typesetting a Book
 
-The template uses the default KOMA-Script class `scrartcl` as the document class because it has some advantages over the default `article` class. For typesetting a book I recommend the corresponding KOMA-Script class `scrbook` instead of the default `book`. You can manually replace the string `scrartcl` in the template with `scrbook`.
+To typeset a book supply the template variable `-V book`.
 
 To get the correct chapter headings you need to tell pandoc that it should convert first level headings (indicated by one `#` in markdown) to chapters with the command line option `--top-level-division=chapter`.
 

--- a/eisvogel.tex
+++ b/eisvogel.tex
@@ -44,7 +44,7 @@
 $if(dir)$$if(latex-dir-rtl)$
 \PassOptionsToPackage{RTLdocument}{bidi}
 $endif$$endif$%
-\documentclass[$if(fontsize)$$fontsize$,$endif$$if(lang)$$babel-lang$,$endif$$if(papersize)$$papersize$paper,$else$a4paper,$endif$$if(beamer)$ignorenonframetext,$if(handout)$handout,$endif$$if(aspectratio)$aspectratio=$aspectratio$,$endif$$endif$$for(classoption)$$classoption$$sep$,$endfor$,tablecaptionabove]{scrartcl}
+\documentclass[$if(fontsize)$$fontsize$,$endif$$if(lang)$$babel-lang$,$endif$$if(papersize)$$papersize$paper,$else$a4paper,$endif$$if(beamer)$ignorenonframetext,$if(handout)$handout,$endif$$if(aspectratio)$aspectratio=$aspectratio$,$endif$$endif$$for(classoption)$$classoption$$sep$,$endfor$,tablecaptionabove]{$if(book)$scrbook$else$scrartcl$endif$}
 $if(beamer)$
 $if(background-image)$
 \usebackgroundtemplate{%

--- a/examples/build.sh
+++ b/examples/build.sh
@@ -31,10 +31,7 @@ pdftoppm -r 150 -png "without-listings/without-listings.pdf" > "without-listings
 pandoc "green-titlepage/green-titlepage.md"   -o "green-titlepage/green-titlepage.pdf"   --from markdown --template "../eisvogel.latex" --listings
 pdftoppm -r 150 -png "green-titlepage/green-titlepage.pdf" > "green-titlepage/green-titlepage.png"
 
-# replace the document class `scrartcl` with `scrbook
-sed 's/scrartcl/scrbook/g' <"../eisvogel.latex" >"../eisvogel-book.latex"
-
-pandoc "book/book.md" -o "book/book.pdf" --from markdown --template "../eisvogel-book.latex" --listings -V classoption=oneside --top-level-division=chapter 
+pandoc "book/book.md" -o "book/book.pdf" --from markdown --template "../eisvogel.latex" --listings -V book -V classoption=oneside --top-level-division=chapter 
 pdftoppm -r 150 -png "book/book.pdf" > "book/book.png"
 
 pandoc "images-and-tables/images-and-tables.md" -o "images-and-tables/images-and-tables.pdf" --from markdown --template "../eisvogel.latex" --listings --resource-path "./images-and-tables/"


### PR DESCRIPTION
Makes typesetting a book possible without editing the template file.

Adds a new template variable `book` which determines the document class. The default is still `scrartcl` but if the variable is set `scrbook` is used.