### PR TITLE
Add support for first-chapter variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ This template defines some new variables to control the appearance of the title 
 	
 	the width of the logo (in points)
 
+- `first-chapter` (defaults to `1`)
+	
+	if typesetting a book with chapter numbers, specifies the number that will be assigned to the first chapter
+
 ## Examples
 
 ### Numbered Sections
@@ -171,7 +175,7 @@ pandoc example.md -o example.pdf --template eisvogel -V lang=de
 
 To typeset a book supply the template variable `-V book`.
 
-To get the correct chapter headings you need to tell pandoc that it should convert first level headings (indicated by one `#` in markdown) to chapters with the command line option `--top-level-division=chapter`.
+To get the correct chapter headings you need to tell pandoc that it should convert first level headings (indicated by one `#` in markdown) to chapters with the command line option `--top-level-division=chapter`. Chapter numbers start at 1. If you need to change that, specify `first-chapter` in the template variables.
 
 There will be one blank page before each chapter because the template is two-sided per default. So if you plan to publish your book as a PDF and don't need a blank page you should add the class option `onesided` which can be done by supplying a template variable `-V classoption=oneside`.
 

--- a/eisvogel.tex
+++ b/eisvogel.tex
@@ -736,6 +736,11 @@ $abstract$
 $endif$
 $endif$
 
+$if(first-chapter)$
+\setcounter{chapter}{$first-chapter$}
+\addtocounter{chapter}{-1}
+$endif$
+
 $for(include-before)$
 $include-before$
 


### PR DESCRIPTION
When typesetting a book, it might be desirable to start numbering chapters at some value other than 1. This PR adds support for that through the first-chapter variable, such as

```
first-chapter: 5
```
to assign 5 to the first chapter encountered.