### PR TITLE
Update Readme with new XDG support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A custom title page      |  A basic example page
 1. Install pandoc from <http://pandoc.org/>. You also need to install [LaTeX](https://en.wikibooks.org/wiki/LaTeX/Installation#Distributions).
 2. Download the latest version of the Eisvogel template from [the release page](https://github.com/Wandmalfarbe/pandoc-latex-template/releases/latest).
 3. Extract the downloaded ZIP archive and open the folder.
-4. Move the template `eisvogel.tex` to your pandoc templates folder and rename the file to `eisvogel.latex`.The location of the templates folder depends on your operating system:
+4. Move the template `eisvogel.tex` to your pandoc templates folder and rename the file to `eisvogel.latex`. The location of the templates folder depends on your operating system:
 	- Unix, Linux, macOS: `$XDG_DATA_HOME/pandoc/templates` or `~/.pandoc/templates/`
 	- Windows XP: `C:\Documents And Settings\USERNAME\Application Data\pandoc\templates`
 	- Windows Vista or later: `C:\Users\USERNAME\AppData\Roaming\pandoc\templates`

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A custom title page      |  A basic example page
 2. Download the latest version of the Eisvogel template from [the release page](https://github.com/Wandmalfarbe/pandoc-latex-template/releases/latest).
 3. Extract the downloaded ZIP archive and open the folder.
 4. Move the template `eisvogel.tex` to your pandoc templates folder and rename the file to `eisvogel.latex`.The location of the templates folder depends on your operating system:
-	- Unix, Linux, macOS: `~/.pandoc/templates/`
+	- Unix, Linux, macOS: `$XDG_DATA_HOME/pandoc/templates` or `~/.pandoc/templates/`
 	- Windows XP: `C:\Documents And Settings\USERNAME\Application Data\pandoc\templates`
 	- Windows Vista or later: `C:\Users\USERNAME\AppData\Roaming\pandoc\templates`
 	


### PR DESCRIPTION
Pandoc supports the XDG specification as of [0bed0ab](https://github.com/jgm/pandoc/commit/0bed0ab5a308f5e72a01fa9bee76488556288862), recently released in version [2.7.2](https://github.com/jgm/pandoc/releases/tag/2.7.2).