### PR TITLE
introduce option `toc-links` (defaults to `all`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ This template defines some new variables to control the appearance of the result
 - `caption-justification` (defaults to `raggedright`)
 
     justification setting for captions (uses the `justification` parameter of the [caption](https://ctan.org/pkg/caption?lang=en) package)
+- `toc-links` (defaults to `all`)
+
+    defines which part of an entry in the table of contents (TOC) is made into a link. Possible values include:
+
+    - `none`: Don't make the TOC into links at all.
+    - `section`: Only make the section/chapter titles into links.
+    - `page`: Only make the page numbers into links.
+    - `all`: Make both the section/chapter titles and the page numbers into links.
 - `toc-own-page` (defaults to `false`)
 
     begin new page after table of contents, when `true`

--- a/eisvogel.tex
+++ b/eisvogel.tex
@@ -274,6 +274,7 @@ $if(colorlinks)$
 $else$
   hidelinks,
 $endif$
+  linktoc=$if(toc-links)$$toc-links$$else$all$endif$,
   breaklinks=true,
   pdfcreator={LaTeX via pandoc with the Eisvogel template}}
 \urlstyle{same} % disable monospaced font for URLs


### PR DESCRIPTION
`toc-links` defines which part of an entry in the table of contents (TOC) is made into a link. Possible values include:

- `none`: Don't make the TOC into links at all.
- `section`: Only make the section/chapter titles into links.
- `page`: Only make the page numbers into links.
- `all`: Make both the section/chapter titles and the page numbers into links.

**Remark:** I'm not sure if the `hyperref` option `linktoc=...` should be added to the second `\hypersetup` call [@ line 850](https://github.com/Wandmalfarbe/pandoc-latex-template/blob/f0407079bb519a7a02ed28ce8a0bdf158c84d12b/eisvogel.tex#L850), too...