### PR TITLE
Add a \keystroke macro to render keyboard keys

### DIFF
--- a/eisvogel.tex
+++ b/eisvogel.tex
@@ -410,6 +410,32 @@ $endif$
 \usepackage{float}
 \floatplacement{figure}{$if(float-placement-figure)$$float-placement-figure$$else$H$endif$}
 
+% Define a \keystroke command, rendering a visual representatiom
+% of a keyboard key
+\usepackage{tikz}
+\usetikzlibrary{shadows}
+\newcommand*\keystroke[1]{
+  \tikz[baseline=(key.base)]
+    \node[
+      draw,
+      text height=1.5ex,
+      text depth=0ex,
+      fill=white,
+      minimum width=1.2em,
+      drop shadow={
+        shadow xshift=0.2ex,
+        shadow yshift=-0.2ex,
+        fill=black,
+        opacity=0.50
+      },
+      rectangle,
+      rounded corners=2pt,
+      inner sep=2.75pt,
+      line width=0.5pt,
+      font=\footnotesize\sffamily
+    ](key) {#1};
+}
+
 $for(header-includes)$
 $header-includes$
 $endfor$


### PR DESCRIPTION
The `keystroke` package seems to render keys with long (generally more than 2 characters) content in a weird way: the outline appears "broken". The following snippet  allows the user to benefit from a similar feature with correct rendering.

Using the native `keystroke` package:
<img width="969" alt="Using the native keystroke package" src="https://user-images.githubusercontent.com/480131/73597025-041eea80-44f6-11ea-8185-a6fc76d6a3ea.png">

Using the suggested snippet:
<img width="960" alt="Using the suggested snippet" src="https://user-images.githubusercontent.com/480131/73597032-10a34300-44f6-11ea-9112-34add4f2cb64.png">

Source: https://tex.stackexchange.com/a/5227

Note: I'm experiencing the same behaviour with the default Pandoc latex template. 