### PR TITLE
Fixed a couple of LuaLaTeX warnings

### DIFF
--- a/eisvogel.tex
+++ b/eisvogel.tex
@@ -60,7 +60,7 @@ $endif$
 $if(papersize)$
   $papersize$paper,
 $else$
-  a4paper,
+  paper=a4,
 $endif$
 $if(beamer)$
   ignorenonframetext,
@@ -74,7 +74,7 @@ $endif$
 $for(classoption)$
   $classoption$$sep$,
 $endfor$
-,tablecaptionabove
+,captions=tableheading
 ]{$if(beamer)$$documentclass$$else$$if(book)$scrbook$else$scrartcl$endif$$endif$}
 $if(beamer)$
 $if(background-image)$


### PR DESCRIPTION
I used pandoc with LuaLaTex as PDF engine to convert my Markdown file to PDF. In the log, it gave me a couple of warnings with workarounds also specified, which I have implemented in this PR.

Warnings:
a4paper is obsolete
tablecaptionabove is deprecated