### PR TITLE
Added documentation and options related to link coloring

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ This template defines some new variables to control the appearance of the result
 
     the text color of the title page
 
+  - `titlepage-urlcolor` (defaults to `default-urlcolor` of `4077C0`)
+
+    the color of URLs on the title page
+
   - `titlepage-rule-color` (defaults to `435488`)
 
     the color of the rule on the top of the title page
@@ -169,6 +173,26 @@ This template defines some new variables to control the appearance of the result
   - `code-block-font-size` (defaults to `\small`)
 
     LaTeX command to change the font size for code blocks. The available values are `\tiny`, `\scriptsize`, `\footnotesize`, `\small`, `\normalsize`, `\large`, `\Large`, `\LARGE`, `\huge` and `\Huge`. This option will change the font size for default code blocks using the verbatim environment and for code blocks generated with listings.
+
+  - `colorlinks` (defaults to `false`)
+
+    enables colored links in the document
+ 
+  - `linkcolor` (defaults to `A50000`)
+  
+    color links within the document
+    
+  - `filecolor` (defaults to `A50000`)
+  
+    color of links to files
+    
+  - `citecolor` (defaults to `4077C0`)
+  
+    color of citation links
+    
+  - `urlcolor` (defaults to `4077C0`)
+  
+    color of links to websites
 
 ## Required LaTeX Packages
 

--- a/eisvogel.tex
+++ b/eisvogel.tex
@@ -275,10 +275,10 @@ $if(keywords)$
 $endif$
 $if(colorlinks)$
   colorlinks=true,
-  linkcolor=$if(linkcolor)$$linkcolor$$else$default-linkcolor$endif$,
-  filecolor=$if(filecolor)$$filecolor$$else$default-filecolor$endif$,
-  citecolor=$if(citecolor)$$citecolor$$else$default-citecolor$endif$,
-  urlcolor=$if(urlcolor)$$urlcolor$$else$default-urlcolor$endif$,
+  linkcolor=$if(linkcolor)$[HTML]$linkcolor$$else$default-linkcolor$endif$,
+  filecolor=$if(filecolor)$[HTML]$filecolor$$else$default-filecolor$endif$,
+  citecolor=$if(citecolor)$[HTML]$citecolor$$else$default-citecolor$endif$,
+  urlcolor=$if(urlcolor)$[HTML]$urlcolor$$else$default-urlcolor$endif$,
 $else$
   hidelinks,
 $endif$

--- a/eisvogel.tex
+++ b/eisvogel.tex
@@ -877,6 +877,7 @@ $endif$
 \noindent
 \\[-1em]
 \color[HTML]{$if(titlepage-text-color)$$titlepage-text-color$$else$5F5F5F$endif$}
+\hypersetup{urlcolor=$if(titlepage-urlcolor)$[HTML]$titlepage-urlcolor$$else$default-urlcolor$endif$}
 \makebox[0pt][l]{\colorRule[$if(titlepage-rule-color)$$titlepage-rule-color$$else$435488$endif$]{1.3\textwidth}{$if(titlepage-rule-height)$$titlepage-rule-height$$else$4$endif$pt}}
 \par
 \noindent


### PR DESCRIPTION
# colorlinks

1. Added documentation for already-present `colorlinks` option.

# titlepage-urlcolor

1. Added new functionality to set custom `urlcolor` on title page via `titlepage-urlcolor` so that links do not disappear on blue-color title-page backgrounds (like one of the example backgrounds in this project) when `colorlinks` is `true`.
2. Added documentation for above option.

# linkcolor, filecolor, citecolor, urlcolor

1. Added `[HTML]` option to `linkcolor`, `filecolor`, `citecolor`, and `urlcolor` to allow for custom colors.
2. Added documentation for above options.