### PR TITLE
Added titlepage-urlcolor

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ This template defines some new variables to control the appearance of the result
 
     the text color of the title page
 
+  - `titlepage-urlcolor` (defaults to `default-urlcolor` of `4077C0`)
+
+    the color of URLs on the title page
+
   - `titlepage-rule-color` (defaults to `435488`)
 
     the color of the rule on the top of the title page

--- a/eisvogel.tex
+++ b/eisvogel.tex
@@ -908,6 +908,7 @@ $endif$
 \noindent
 \\[-1em]
 \color[HTML]{$if(titlepage-text-color)$$titlepage-text-color$$else$5F5F5F$endif$}
+\hypersetup{urlcolor=$if(titlepage-urlcolor)$[HTML]$titlepage-urlcolor$$else$default-urlcolor$endif$}
 \makebox[0pt][l]{\colorRule[$if(titlepage-rule-color)$$titlepage-rule-color$$else$435488$endif$]{1.3\textwidth}{$if(titlepage-rule-height)$$titlepage-rule-height$$else$4$endif$pt}}
 \par
 \noindent


### PR DESCRIPTION
Blue links can end up on the title page if they are used in the `author` or `subtitle` YAML. If the title page background is blue, they can be hard to see.