### PR TITLE
Added `colorlinks-use-html-colors` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ This template defines some new variables to control the appearance of the result
 
   - `colorlinks-use-html-colors` (defaults to `false`)
 
-    Use `HTML` colors for `linkcolor`, `filecolor`, `citecolor`, and `urlcolor`,
+    Use `HTML` colors for `linkcolor`, `filecolor`, `citecolor`, and `urlcolor`.
 
 ## Required LaTeX Packages
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,10 @@ This template defines some new variables to control the appearance of the result
 
     LaTeX command to change the font size for code blocks. The available values are `\tiny`, `\scriptsize`, `\footnotesize`, `\small`, `\normalsize`, `\large`, `\Large`, `\LARGE`, `\huge` and `\Huge`. This option will change the font size for default code blocks using the verbatim environment and for code blocks generated with listings.
 
+  - `colorlinks-use-html-colors` (defaults to `false`)
+
+    Use `HTML` colors for `linkcolor`, `filecolor`, `citecolor`, and `urlcolor`,
+
 ## Required LaTeX Packages
 
 LaTeX manages addons and additional functionality in so called packages. You

--- a/eisvogel.tex
+++ b/eisvogel.tex
@@ -277,10 +277,17 @@ $if(keywords)$
 $endif$
 $if(colorlinks)$
   colorlinks=true,
-  linkcolor=$if(linkcolor)$$linkcolor$$else$default-linkcolor$endif$,
-  filecolor=$if(filecolor)$$filecolor$$else$default-filecolor$endif$,
-  citecolor=$if(citecolor)$$citecolor$$else$default-citecolor$endif$,
-  urlcolor=$if(urlcolor)$$urlcolor$$else$default-urlcolor$endif$,
+  $if(colorlinks-use-html-colors)$
+    linkcolor=$if(linkcolor)$[HTML]$linkcolor$$else$default-linkcolor$endif$,
+    filecolor=$if(filecolor)$[HTML]$filecolor$$else$default-filecolor$endif$,
+    citecolor=$if(citecolor)$[HTML]$citecolor$$else$default-citecolor$endif$,
+    urlcolor=$if(urlcolor)$[HTML]$urlcolor$$else$default-urlcolor$endif$,
+  $else$
+    linkcolor=$if(linkcolor)$$linkcolor$$else$default-linkcolor$endif$,
+    filecolor=$if(filecolor)$$filecolor$$else$default-filecolor$endif$,
+    citecolor=$if(citecolor)$$citecolor$$else$default-citecolor$endif$,
+    urlcolor=$if(urlcolor)$$urlcolor$$else$default-urlcolor$endif$,
+  $endif$
 $else$
   hidelinks,
 $endif$


### PR DESCRIPTION
Added a `colorlinks-use-html-colors` option to:

> Use `HTML` colors for `linkcolor`, `filecolor`, `citecolor`, and `urlcolor`.

This is an optional attribute and allows the use of `HTML` link colors without breaking compatibility with the Pandoc default template.