### PR TITLE
Adding an option to make the title on 1st page

### DIFF
--- a/eisvogel.tex
+++ b/eisvogel.tex
@@ -954,6 +954,16 @@ $endif$
 \end{flushleft}
 \end{titlepage}
 \restoregeometry
+$else$
+$if(maketitle)$
+\vspace*{-3\baselineskip}
+\begin{center}
+  {\LARGE \thetitle}\\
+  \vspace{0.7\baselineskip}
+  {\large \theauthor}
+\end{center}
+\thispagestyle{plain}
+$endif$
 $endif$
 $endif$
 


### PR DESCRIPTION
The options available with respect to showing title/author are the following:
  - either no title ;
  - or nice title page of its own.
However, especially for small documents, it could make sense to make the title appear on top of the first page.
This commit adds the option maketitle to display the title on first page rather than having a title page or no title at all. In spirit it just performs a \maketitle. However, I found the the \maketitle command of scrartcl.cls was taking much room for nothing and was not fitting that well with the overall template. So I made it more compact.