### PR TITLE
Separate font size for `lstinline` and `lstlisting`

### DIFF
--- a/eisvogel.tex
+++ b/eisvogel.tex
@@ -751,7 +751,13 @@ $else$
   framexleftmargin = 2.5em,
 $endif$
   backgroundcolor  = \color{listing-background},
-  basicstyle       = \color{listing-text-color}\linespread{1.0}$if(code-block-font-size)$$code-block-font-size$$else$\small$endif$\ttfamily{},
+  basicstyle       = \color{listing-text-color}\linespread{1.0}%
+                      \lst@ifdisplaystyle%
+                      $if(code-block-font-size)$$code-block-font-size$$else$\small$endif$%
+                      $if(code-inline-font-size)$
+                      \else$code-inline-font-size$%
+                      $endif$%
+                      \fi\ttfamily{},
   breaklines       = true,
   frame            = single,
   framesep         = 0.19em,


### PR DESCRIPTION
Thanks for this great template!

I often find myself needing to change the `code-block-font-size` to a smaller font in order to avoid line wraps in listings. However this also affects inline code. So I've been having to avoid using this variable and instead opt to something like this to avoid the issue:
```pandoc
\lstset{basicstyle=\scriptsize}

~~~sh
$ this code wont wrap
# here is a comment
~~~

\lstset{basicstyle=\normalsize}

```

This PR is an example of how to avoid this by separating the font size used in `lstlisting` environments and other listing environments (i.e. inline).

Let me know if I should instead fall back to `code-block-font-size` for inline listings instead if you want it to be backwards compatible. (although I prefer defaulting to the surrounding text, as the current implementation does).