### PR TITLE
Do not include title page in page count

### DIFF
--- a/eisvogel.tex
+++ b/eisvogel.tex
@@ -952,6 +952,7 @@ $endif$
 \end{flushleft}
 \end{titlepage}
 \restoregeometry
+\pagenumbering{arabic} 
 $endif$
 $endif$
 


### PR DESCRIPTION
When a title page is used it is included in the page count. This means that the first page after the title page is '2' rather than '1.' Adding the pagenumbering instruction after creating the title page will restart the page count at the first page after the title page. This means that the first page after the title page is '1.'