### PR TITLE
Fix headers and footers bug introduced in commit 4b7c6f41e4bda1645eb5…

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,21 @@ This template defines some new variables to control the appearance of the result
 
     avoid page break inside listings
 
+  - `listings-disable-font-styling` (defaults to `false`)
+
+    disables the bold and italic font styles used for certain keywords inside listings
+
+  - `listings-text-color` (defaults to `000000`)
+
+    the color of text inside listings. Other color options inside listings are:
+
+    - `listings-keyword-color`
+    - `listings-keyword-2-color`
+    - `listings-keyword-3-color`
+    - `listings-identifier-color`
+    - `listings-string-color`
+    - `listings-comment-color`
+
   - `disable-header-and-footer` (default to `false`)
 
     disables the header and footer completely on all pages

--- a/README.md
+++ b/README.md
@@ -100,21 +100,6 @@ This template defines some new variables to control the appearance of the result
 
     avoid page break inside listings
 
-  - `listings-disable-font-styling` (defaults to `false`)
-
-    disables the bold and italic font styles used for certain keywords inside listings
-
-  - `listings-text-color` (defaults to `000000`)
-
-    the color of text inside listings. Other color options inside listings are:
-
-    - `listings-keyword-color`
-    - `listings-keyword-2-color`
-    - `listings-keyword-3-color`
-    - `listings-identifier-color`
-    - `listings-string-color`
-    - `listings-comment-color`
-
   - `disable-header-and-footer` (default to `false`)
 
     disables the header and footer completely on all pages

--- a/eisvogel.tex
+++ b/eisvogel.tex
@@ -853,12 +853,12 @@ $else$
 
 \newpairofpagestyles{eisvogel-header-footer}{
   \clearpairofpagestyles
-  \ihead[$if(header-right)$$header-right$$else$$date$$endif$]{$if(header-left)$$header-left$$else$$title$$endif$}
-  \chead[$if(header-center)$$header-center$$else$$endif$]{$if(header-center)$$header-center$$else$$endif$}
-  \ohead[$if(header-left)$$header-left$$else$$title$$endif$]{$if(header-right)$$header-right$$else$$date$$endif$}
-  \ifoot[$if(footer-right)$$footer-right$$else$\thepage$endif$]{$if(footer-left)$$footer-left$$else$$for(author)$$author$$sep$, $endfor$$endif$}
-  \cfoot[$if(footer-center)$$footer-center$$else$$endif$]{$if(footer-center)$$footer-center$$else$$endif$}
-  \ofoot[$if(footer-left)$$footer-left$$else$$for(author)$$author$$sep$, $endfor$$endif$]{$if(footer-right)$$footer-right$$else$\thepage$endif$}
+  \ihead*{$if(header-left)$$header-left$$else$$title$$endif$}
+  \chead*{$if(header-center)$$header-center$$else$$endif$}
+  \ohead*{$if(header-right)$$header-right$$else$$date$$endif$}
+  \ifoot*{$if(footer-left)$$footer-left$$else$$for(author)$$author$$sep$, $endfor$$endif$}
+  \cfoot*{$if(footer-center)$$footer-center$$else$$endif$}
+  \ofoot*{$if(footer-right)$$footer-right$$else$\thepage$endif$}
   \addtokomafont{pageheadfoot}{\upshape}
 }
 \pagestyle{eisvogel-header-footer}

--- a/eisvogel.tex
+++ b/eisvogel.tex
@@ -729,19 +729,19 @@ $if(listings)$
 %
 % general listing colors
 %
-\definecolor{listing-background}{HTML}{F7F7F7}
-\definecolor{listing-rule}{HTML}{B3B2B3}
-\definecolor{listing-numbers}{HTML}{B3B2B3}
-\definecolor{listing-text-color}{HTML}{000000}
-\definecolor{listing-keyword}{HTML}{435489}
-\definecolor{listing-keyword-2}{HTML}{1284CA} % additional keywords
-\definecolor{listing-keyword-3}{HTML}{9137CB} % additional keywords
-\definecolor{listing-identifier}{HTML}{435489}
-\definecolor{listing-string}{HTML}{00999A}
-\definecolor{listing-comment}{HTML}{8E8E8E}
+\definecolor{listing-background}{HTML}{$if(listings-background-color)$$listings-background-color$$else$F7F7F7$endif$}
+\definecolor{listing-rule}{HTML}{$if(listings-rule-color)$$listings-rule-color$$else$B3B2B3$endif$}
+\definecolor{listing-numbers}{HTML}{$if(listings-numbers-color)$$listings-numbers-color$$else$B3B2B3$endif$}
+\definecolor{listing-text-color}{HTML}{$if(listings-text-color)$$listings-text-color$$else$000000$endif$}
+\definecolor{listing-keyword}{HTML}{$if(listings-keyword-color)$$listings-keyword-color$$else$435489$endif$}
+\definecolor{listing-keyword-2}{HTML}{$if(listings-keyword-2-color)$$listings-keyword-2-color$$else$1284CA$endif$} % additional keywords
+\definecolor{listing-keyword-3}{HTML}{$if(listings-keyword-3-color)$$listings-keyword-3-color$$else$9137CB$endif$} % additional keywords
+\definecolor{listing-identifier}{HTML}{$if(listings-identifier-color)$$listings-identifier-color$$else$435489$endif$}
+\definecolor{listing-string}{HTML}{$if(listings-string-color)$$listings-string-color$$else$00999A$endif$}
+\definecolor{listing-comment}{HTML}{$if(listings-comment-color)$$listings-comment-color$$else$8E8E8E$endif$}
 
 \lstdefinestyle{eisvogel_listing_style}{
-  language         = java,
+  language         = $if(listings-syntax-highlighting-language)$$listings-syntax-highlighting-language$$else$java$endif$,
 $if(listings-disable-line-numbers)$
   xleftmargin      = 0.6em,
   framexleftmargin = 0.4em,
@@ -763,9 +763,9 @@ $endif$
   belowskip        = 0.1em,
   abovecaptionskip = 0em,
   belowcaptionskip = 1.0em,
-  keywordstyle     = {\color{listing-keyword}\bfseries},
-  keywordstyle     = {[2]\color{listing-keyword-2}\bfseries},
-  keywordstyle     = {[3]\color{listing-keyword-3}\bfseries\itshape},
+  keywordstyle     = {\color{listing-keyword}$if(listings-disable-font-styling)$$else$\bfseries$endif$},
+  keywordstyle     = {[2]\color{listing-keyword-2}$if(listings-disable-font-styling)$$else$\bfseries$endif$},
+  keywordstyle     = {[3]\color{listing-keyword-3}$if(listings-disable-font-styling)$$else$\bfseries\itshape$endif$},
   sensitive        = true,
   identifierstyle  = \color{listing-identifier},
   commentstyle     = \color{listing-comment},

--- a/eisvogel.tex
+++ b/eisvogel.tex
@@ -729,19 +729,19 @@ $if(listings)$
 %
 % general listing colors
 %
-\definecolor{listing-background}{HTML}{$if(listings-background-color)$$listings-background-color$$else$F7F7F7$endif$}
-\definecolor{listing-rule}{HTML}{$if(listings-rule-color)$$listings-rule-color$$else$B3B2B3$endif$}
-\definecolor{listing-numbers}{HTML}{$if(listings-numbers-color)$$listings-numbers-color$$else$B3B2B3$endif$}
-\definecolor{listing-text-color}{HTML}{$if(listings-text-color)$$listings-text-color$$else$000000$endif$}
-\definecolor{listing-keyword}{HTML}{$if(listings-keyword-color)$$listings-keyword-color$$else$435489$endif$}
-\definecolor{listing-keyword-2}{HTML}{$if(listings-keyword-2-color)$$listings-keyword-2-color$$else$1284CA$endif$} % additional keywords
-\definecolor{listing-keyword-3}{HTML}{$if(listings-keyword-3-color)$$listings-keyword-3-color$$else$9137CB$endif$} % additional keywords
-\definecolor{listing-identifier}{HTML}{$if(listings-identifier-color)$$listings-identifier-color$$else$435489$endif$}
-\definecolor{listing-string}{HTML}{$if(listings-string-color)$$listings-string-color$$else$00999A$endif$}
-\definecolor{listing-comment}{HTML}{$if(listings-comment-color)$$listings-comment-color$$else$8E8E8E$endif$}
+\definecolor{listing-background}{HTML}{F7F7F7}
+\definecolor{listing-rule}{HTML}{B3B2B3}
+\definecolor{listing-numbers}{HTML}{B3B2B3}
+\definecolor{listing-text-color}{HTML}{000000}
+\definecolor{listing-keyword}{HTML}{435489}
+\definecolor{listing-keyword-2}{HTML}{1284CA} % additional keywords
+\definecolor{listing-keyword-3}{HTML}{9137CB} % additional keywords
+\definecolor{listing-identifier}{HTML}{435489}
+\definecolor{listing-string}{HTML}{00999A}
+\definecolor{listing-comment}{HTML}{8E8E8E}
 
 \lstdefinestyle{eisvogel_listing_style}{
-  language         = $if(listings-syntax-highlighting-language)$$listings-syntax-highlighting-language$$else$java$endif$,
+  language         = java,
 $if(listings-disable-line-numbers)$
   xleftmargin      = 0.6em,
   framexleftmargin = 0.4em,
@@ -763,9 +763,9 @@ $endif$
   belowskip        = 0.1em,
   abovecaptionskip = 0em,
   belowcaptionskip = 1.0em,
-  keywordstyle     = {\color{listing-keyword}$if(listings-disable-font-styling)$$else$\bfseries$endif$},
-  keywordstyle     = {[2]\color{listing-keyword-2}$if(listings-disable-font-styling)$$else$\bfseries$endif$},
-  keywordstyle     = {[3]\color{listing-keyword-3}$if(listings-disable-font-styling)$$else$\bfseries\itshape$endif$},
+  keywordstyle     = {\color{listing-keyword}\bfseries},
+  keywordstyle     = {[2]\color{listing-keyword-2}\bfseries},
+  keywordstyle     = {[3]\color{listing-keyword-3}\bfseries\itshape},
   sensitive        = true,
   identifierstyle  = \color{listing-identifier},
   commentstyle     = \color{listing-comment},


### PR DESCRIPTION
Hi,

I think that commit [4b7c6f41e4bda1645eb5b88d9e510348dcf261f3](https://github.com/Wandmalfarbe/pandoc-latex-template/commit/4b7c6f41e4bda1645eb5b88d9e510348dcf261f3) introduced an unintended side-effect caused by a difference in the syntax of `scrlayer-scrpage` and `fancyhdr`.

When building a document with the option `oneside` set, I still get two different versions of the headers and footers:

![image](https://user-images.githubusercontent.com/2010034/125852067-0ac1f03d-5a1c-4f1a-97d6-f9b957202998.png)

In my opinion, this should not be the case. Instead, if `oneside` is set, I should always get the same headers and footers, like this (taken from the version in this pull request):

![image](https://user-images.githubusercontent.com/2010034/125852132-516843c4-7a64-4f7e-b82a-e55d1241447d.png)

On [page 267 of the KOMA-Script manual](https://ftp.gwdg.de/pub/ctan/macros/latex/contrib/koma-script/doc/scrguien.pdf#page=267) we can see that `scrlayer-scrpage` only requires two arguments for plain `scrheadings` and normal `scrheadings`, e. g. `\ihead*[plain.scrheadings content]{scrheadings content}`.

fancyhdr on the other side requires two arguments for even and odd pages, as can be seen on [page 45 of the manual](https://ctan.space-pro.be/tex-archive/macros/latex/contrib/fancyhdr/fancyhdr.pdf#page=45):

> As you see, if there is an optional parameter, this one applies to the evenpages, whereas the required parameter applies to the odd pages

Previous versions of Eisvogel (i. e. v 2.0.0) had a completely different plain style for headers and footers (a centered page number in a footer without a rule and no header at all):

![image](https://user-images.githubusercontent.com/2010034/125852186-b24cd684-7858-4254-be70-00b4d0aa806a.png)

If my suspicions about the author's intentions are correct, we can simply replace the code with two arguments with the star-version - as has been done in this pull request.

By the way - this also has the correct behavior if `oneside` is not set:

![image](https://user-images.githubusercontent.com/2010034/125852237-b248e609-c190-465c-8b96-156efea90068.png)