### PR TITLE
Added support for titlepage-logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ This template defines some new variables to control the appearance of the result
 
     the height of the rule on the top of the title page (in points)
 
+  - `titlepage-logo`
+
+    path to an image that will be displayed on the title page. The path is always relative to where pandoc is executed. The option `--resource-path` has no effect.
+
   - `titlepage-background`
 
     the path to a background image for the title page. The background image is scaled to cover the entire page. In the examples folder under `titlepage-background` are a few example background images.
@@ -139,11 +143,6 @@ This template defines some new variables to control the appearance of the result
   - `book` (defaults to `false`)
 
     typeset as book
-
-  - `titlepage-logo` or `logo`
-
-    path to an image that will be displayed on the title page. The path is always relative to where pandoc is executed. The option `--resource-path` has no effect.
-    Use `titlepage-logo` if you want the logo only in the Eisvogel rendering but not in other TeX formats (like Beamer). See [issue #265](https://github.com/Wandmalfarbe/pandoc-latex-template/issues/265).  
 
   - `logo-width` (defaults to `35mm`)
 

--- a/README.md
+++ b/README.md
@@ -140,9 +140,10 @@ This template defines some new variables to control the appearance of the result
 
     typeset as book
 
-  - `logo`
+  - `titlepage-logo` or `logo`
 
     path to an image that will be displayed on the title page. The path is always relative to where pandoc is executed. The option `--resource-path` has no effect.
+    Use `titlepage-logo` if you want the logo only in the Eisvogel rendering but not in other TeX formats (like Beamer). See [issue #265](https://github.com/Wandmalfarbe/pandoc-latex-template/issues/265).  
 
   - `logo-width` (defaults to `35mm`)
 
@@ -338,7 +339,7 @@ There will be one blank page before each chapter because the template is two-sid
 The following section lists common errors and their solutions when using the
 Eisvogel template.
 
-### LaTeX Errors `Missing endcsname inserted` or `File x not found` when using `titlepage-background` or `logo`
+### LaTeX Errors `Missing endcsname inserted` or `File x not found` when using `titlepage-background`, `logo`, or `titlepage-logo`.
 
 ``` latex
 Error producing PDF.

--- a/eisvogel.tex
+++ b/eisvogel.tex
@@ -321,7 +321,10 @@ $else$
 \usepackage[margin=2.5cm,includehead=true,includefoot=true,centering,$for(geometry)$$geometry$$sep$,$endfor$]{geometry}
 $endif$
 $endif$
-$if(logo)$
+$if(titlepage-logo)$
+\usepackage[export]{adjustbox}
+\usepackage{graphicx}
+$elseif(logo)$
 \usepackage[export]{adjustbox}
 \usepackage{graphicx}
 $endif$
@@ -917,7 +920,10 @@ $else$
 }
 $endif$
 
-$if(logo)$
+$if(titlepage-logo)$
+\noindent
+\includegraphics[width=$if(logo-width)$$logo-width$$else$35mm$endif$, left]{$titlepage-logo$}
+$elseif(logo)$
 \noindent
 \includegraphics[width=$if(logo-width)$$logo-width$$else$35mm$endif$, left]{$logo$}
 $endif$

--- a/eisvogel.tex
+++ b/eisvogel.tex
@@ -324,9 +324,6 @@ $endif$
 $if(titlepage-logo)$
 \usepackage[export]{adjustbox}
 \usepackage{graphicx}
-$elseif(logo)$
-\usepackage[export]{adjustbox}
-\usepackage{graphicx}
 $endif$
 $if(beamer)$
 \newif\ifbibliography
@@ -923,9 +920,6 @@ $endif$
 $if(titlepage-logo)$
 \noindent
 \includegraphics[width=$if(logo-width)$$logo-width$$else$35mm$endif$, left]{$titlepage-logo$}
-$elseif(logo)$
-\noindent
-\includegraphics[width=$if(logo-width)$$logo-width$$else$35mm$endif$, left]{$logo$}
 $endif$
 
 $if(titlepage-background)$

--- a/examples/title-page-logo/document.md
+++ b/examples/title-page-logo/document.md
@@ -10,7 +10,7 @@ titlepage: true
 titlepage-text-color: "7137C8"
 titlepage-rule-color: "7137C8"
 titlepage-rule-height: 2
-logo: "logo.pdf"
+titlepage-logo: "logo.pdf"
 logo-width: 30mm
 ...
 


### PR DESCRIPTION
This PR implements https://github.com/Wandmalfarbe/pandoc-latex-template/issues/265.

I also updated the documentation accordingly. 

It should be fully backwards-compatible with existing documents, i.e. documents using `logo` as before will not be changed.
