### PR TITLE
Add /usr/share/pandoc to possible template dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A clean **pandoc LaTeX template** to convert your markdown files to PDF or LaTeX
 2.  Download the latest version of the Eisvogel template from [the release page](https://github.com/Wandmalfarbe/pandoc-latex-template/releases/latest).
 3.  Extract the downloaded ZIP archive and open the folder.
 4.  Move the template `eisvogel.latex` to your pandoc templates folder. The location of the templates folder depends on your operating system:
-      - Unix, Linux, macOS: `/Users/USERNAME/.local/share/pandoc/templates/` or `/Users/USERNAME/.pandoc/templates/`
+      - Unix, Linux, macOS: `/Users/USERNAME/.local/share/pandoc/templates/` or `/Users/USERNAME/.pandoc/templates/` or `/usr/share/pandoc/data/templates/`
       - Windows Vista or later: `C:\Users\USERNAME\AppData\Roaming\pandoc\templates\`
 
     If there are no folders called `templates` or `pandoc` you need to create them and put the template `eisvogel.latex` inside. You can find the default user data directory on your system by looking at the output of `pandoc --version`.


### PR DESCRIPTION
For me, only this directory works (pandoc 2.5.0 on Zorin Linux (basically Ubuntu)).