### PR TITLE
fix table-header coloring TODO for table-use-row-colors

### DIFF
--- a/eisvogel.tex
+++ b/eisvogel.tex
@@ -663,11 +663,6 @@ $if(tables)$
 \renewcommand{\arraystretch}{1.3}     % spacing (padding)
 
 $if(table-use-row-colors)$
-% TODO: This doesn't work anymore. I don't know why.
-% Reset rownum counter so that each table
-% starts with the same row colors.
-% https://tex.stackexchange.com/questions/170637/restarting-rowcolors
-%
 % Unfortunately the colored cells extend beyond the edge of the
 % table because pandoc uses @-expressions (@{}) like so:
 %
@@ -675,13 +670,11 @@ $if(table-use-row-colors)$
 % \end{longtable}
 %
 % https://en.wikibooks.org/wiki/LaTeX/Tables#.40-expressions
-\let\oldlongtable\longtable
-\let\endoldlongtable\endlongtable
-\renewenvironment{longtable}{
-\rowcolors{3}{}{table-row-color!100}  % row color
-\oldlongtable} {
-\endoldlongtable
-\global\rownum=0\relax}
+\usepackage{etoolbox}
+\AtBeginEnvironment{longtable}{\rowcolors{2}{}{table-row-color!100}}
+\preto{\toprule}{\hiderowcolors}{}{}
+\appto{\endhead}{\showrowcolors}{}{}
+\appto{\endfirsthead}{\showrowcolors}{}{}
 $endif$
 $endif$
 


### PR DESCRIPTION
I found an interesting workaround to the `table-use-row-colors` issue mentioned in this TODO:

https://github.com/Wandmalfarbe/pandoc-latex-template/blob/04e329698d01c3a25aa72ad81d98483284669316/eisvogel.tex#L665-L684

Another user recommended a solution here:

https://github.com/jgm/pandoc/issues/7421#issuecomment-881732047

I've prepared this change based on what's been working for me in my fork of this template (as directly using the suggestion from the bug wasn't working properly). I'm not really a LaTeX person, so feel free to suggest improvements or disregard this change entirely.