### PR TITLE
Add support for pandoc 3

### DIFF
--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -11,7 +11,7 @@ jobs:
         fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
     - name: Setup pandoc
       env:
-        PANDOC_VERSION: "2.19.2"
+        PANDOC_VERSION: "3.0"
       run: |
         wget -qO- https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz | sudo tar xzf - --strip-components 1 -C /usr/local/
     - name: Setup TexLive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project are documented in this file. On the [releases page](https://github.com/Wandmalfarbe/pandoc-latex-template/releases/) you can see all released versions of the Eisvogel template and download the [latest version](https://github.com/Wandmalfarbe/pandoc-latex-template/releases/latest).
 
+## [2.2.0] - 2023-01-22
+
+- Merge changes from the pandoc default LaTeX template (as of 2023-01-13, [909ced5](https://github.com/jgm/pandoc/blob/909ced5153e2c7cefd5018c39f83231824940fb8/data/templates/default.latex)).
+  - This change adds support for pandoc 3.
+
 ## [2.1.0] - 2022-12-04
 
 - Merge changes from the pandoc default LaTeX template (as of 2022-11-19, [144bf90ab9](https://github.com/jgm/pandoc/blob/144bf90ab92b517dd721baf80f121f86187ccd61/data/templates/default.latex)).
@@ -138,6 +143,7 @@ All notable changes to this project are documented in this file. On the [release
 
 - First release of the template as a ZIP file with the examples.
 
+[2.2.0]: https://github.com/Wandmalfarbe/pandoc-latex-template/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/Wandmalfarbe/pandoc-latex-template/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/Wandmalfarbe/pandoc-latex-template/compare/v1.6.1...v2.0.0
 [1.6.1]: https://github.com/Wandmalfarbe/pandoc-latex-template/compare/v1.6.0...v1.6.1

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Build Status](https://travis-ci.com/Wandmalfarbe/pandoc-latex-template.svg?branch=master)](https://travis-ci.com/Wandmalfarbe/pandoc-latex-template)
 
-A clean **pandoc LaTeX template** to convert your markdown files to PDF or LaTeX. It is designed for lecture notes and exercises with a focus on computer science. The template is compatible with pandoc 2.
+A clean **pandoc LaTeX template** to convert your markdown files to PDF or LaTeX. It is designed for lecture notes and exercises with a focus on computer science. The template is compatible with pandoc 3.
 
 ## Preview
 

--- a/eisvogel.tex
+++ b/eisvogel.tex
@@ -1,6 +1,6 @@
 %%
-% Copyright (c) 2017 - 2022, Pascal Wagler;
-% Copyright (c) 2014 - 2022, John MacFarlane
+% Copyright (c) 2017 - 2023, Pascal Wagler;
+% Copyright (c) 2014 - 2023, John MacFarlane
 %
 % All rights reserved.
 %
@@ -383,6 +383,9 @@ $if(numbersections)$
 $else$
 \setcounter{secnumdepth}{-\maxdimen} % remove section numbering
 $endif$
+$if(subfigure)$
+\usepackage{subcaption}
+$endif$
 $if(beamer)$
 $else$
 $if(block-headings)$
@@ -433,6 +436,12 @@ $if(lang)$
 \fi
 $if(babel-lang)$
 \babelprovide[main,import]{$babel-lang$}
+$if(mainfont)$
+\ifPDFTeX
+\else
+\babelfont[$babel-lang$]{rm}{$mainfont$}
+\fi
+$endif$
 $endif$
 $for(babel-otherlangs)$
 \babelprovide[import]{$babel-otherlangs$}


### PR DESCRIPTION
- Merge changes from the pandoc default LaTeX template.
- Change pandoc version to `3.0` in the GitHub workflow.
- Change supported pandoc version to `3` in the README.md.
- Change copyright year.