### PR TITLE
feat: Add CJKsansfont and CJKmonofont for XeLatex

### DIFF
--- a/eisvogel.tex
+++ b/eisvogel.tex
@@ -223,6 +223,18 @@ $if(CJKmainfont)$
     \setmainjfont[$for(CJKoptions)$$CJKoptions$$sep$,$endfor$]{$CJKmainfont$}
   \fi
 $endif$
+$if(CJKsansfont)$
+  \ifXeTeX
+    \usepackage{xeCJK}
+    \setCJKsansfont[$for(CJKoptions)$$CJKoptions$$sep$,$endfor$]{$CJKsansfont$}
+  \fi
+$endif$
+$if(CJKmonofont)$
+  \ifXeTeX
+    \usepackage{xeCJK}
+    \setCJKmonofont[$for(CJKoptions)$$CJKoptions$$sep$,$endfor$]{$CJKmonofont$}
+  \fi
+$endif$
 \fi
 $if(zero-width-non-joiner)$
 %% Support for zero-width non-joiner characters.


### PR DESCRIPTION
The XeLaTex supports `CJKsansfont` and `CJKmonofont` which is useful to change the CJK fonts for the titles and codes.

The following args were tested and worked well.

```
---

mainfont: "Noto Serif SC"
sansfont: "Noto Sans SC"
monofont: "Ubuntu Mono"
CJKmainfont: "Noto Serif SC"
CJKsansfont: "Noto Sans SC"
CJKmonofont: "Noto Sans SC"

...
```