### PR TITLE
Fix placement of float figures (tables, images, etc.)

### DIFF
--- a/eisvogel.tex
+++ b/eisvogel.tex
@@ -374,7 +374,10 @@ $if(graphics)$
 \setkeys{Gin}{width=\maxwidth,height=\maxheight,keepaspectratio}
 % Set default figure placement to htbp
 \makeatletter
-\def\fps@figure{htbp}
+% Make use of float-package and set default placement for figures to H.
+% The option H means 'PUT IT HERE' (as  opposed to the standard h option which means 'You may put it here if you like').
+\usepackage{float}
+\floatplacement{figure}{$if(float-placement-figure)$$float-placement-figure$$else$H$endif$}
 \makeatother
 $endif$
 $if(svg)$


### PR DESCRIPTION
- The added `float` package from PR #12 has accidentally been overwritten with changes from the default template.
- The option `float-placement-figure` is also restored.

This shoud fix #315 and #316.