### PR TITLE
Fix a syntax error

### DIFF
--- a/eisvogel.tex
+++ b/eisvogel.tex
@@ -463,7 +463,7 @@ $endif$
 $for(babel-otherlangs)$
 \babelprovide[import]{$babel-otherlangs$}
 $endfor$
-$for(babelfonts/pairs)$
+$for(babelfonts.pairs)$
 \babelfont[$babelfonts.key$]{rm}{$babelfonts.value$}
 $endfor$
 % get rid of language-specific shorthands (see #6817):


### PR DESCRIPTION
`$for(babelfonts/pairs)$` will cause an error:

```
"template" (line 466, column 16):
unexpected "/"
expecting "." or ")$"
```