### PR TITLE
Add option to enable numbered bookmarks

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -168,6 +168,10 @@ This template defines some new variables to control the appearance of the result
 
     LaTeX command to change the font size for code blocks. The available values are `\tiny`, `\scriptsize`, `\footnotesize`, `\small`, `\normalsize`, `\large`, `\Large`, `\LARGE`, `\huge` and `\Huge`. This option will change the font size for default code blocks using the verbatim environment and for code blocks generated with listings.
 
+  - `bookmarks-numbered` (defaults to `false`)
+
+    Use numbered bookmarks for sections and chapters. Required pandoc argument `--number-sections`.
+
 ## Required LaTeX Packages
 
 LaTeX manages addons and additional functionality in so called packages. You

--- a/docs/index.md
+++ b/docs/index.md
@@ -170,7 +170,7 @@ This template defines some new variables to control the appearance of the result
 
   - `bookmarks-numbered` (defaults to `false`)
 
-    Use numbered bookmarks for sections and chapters. Required pandoc argument `--number-sections`.
+    Use numbered bookmarks for sections and chapters. Requires the pandoc argument `--number-sections`.
 
 ## Required LaTeX Packages
 

--- a/eisvogel.tex
+++ b/eisvogel.tex
@@ -529,6 +529,9 @@ $if(verbatim-in-note)$
 \VerbatimFootnotes % allow verbatim text in footnotes
 $endif$
 \hypersetup{
+$if(bookmarks-numbered)$
+  bookmarksnumbered,
+$endif$
 $if(title-meta)$
   pdftitle={$title-meta$},
 $endif$


### PR DESCRIPTION
Add the following option

>   - `bookmarks-numbered` (defaults to `false`)
> 
>     Use numbered bookmarks for sections and chapters. Requires pandoc argument `--number-sections`.