### PR TITLE
fix: add missing ulem package

### DIFF
--- a/eisvogel.tex
+++ b/eisvogel.tex
@@ -301,6 +301,7 @@ $endif$
 $if(verbatim-in-note)$
 \usepackage{fancyvrb}
 $endif$
+\usepackage{ulem}
 \usepackage{xcolor}
 \definecolor{default-linkcolor}{HTML}{A50000}
 \definecolor{default-filecolor}{HTML}{A50000}


### PR DESCRIPTION
The `ulem` package has been missing in the LaTeX template. It is mentioned in the documentation though.

Therefore, it is now added to allow for rendering strike-through text.

PS: thanks for this great template. I like it a lot!