### PR TITLE
feat: merge changes from pandoc 3.8.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project are documented in this file. On the [releases page](https://github.com/Wandmalfarbe/pandoc-latex-template/releases/) you can see all released versions of the Eisvogel template and download the [latest version](https://github.com/Wandmalfarbe/pandoc-latex-template/releases/latest).
 
+## [3.3.0] - 2025-11-22
+
+- feat: merge changes from the pandoc default LaTeX template from version 3.8.2.1 ([8baa07f](https://github.com/jgm/pandoc-templates/commit/8baa07f0ebb69cd2df10302e4f1f056a828ecb59)).
+    - This resolves an incompatibility between Eisvogel and pandoc >= 3.8.2.1 because of the introduction of `\newcounter{none}` in [jgm/pandoc#11201](https://github.com/jgm/pandoc/issues/11201)
+
 ## [3.2.1] - 2025-09-20
 
 - docs: add three examples for changing the document font
@@ -229,6 +234,7 @@ the [documentation on docker hub](https://hub.docker.com/r/pandoc/extra).
 
 - First release of the template as a ZIP file with the examples.
 
+[3.3.0]: https://github.com/Wandmalfarbe/pandoc-latex-template/compare/v3.2.1...v3.3.0
 [3.2.1]: https://github.com/Wandmalfarbe/pandoc-latex-template/compare/v3.2.0...v3.2.1
 [3.2.0]: https://github.com/Wandmalfarbe/pandoc-latex-template/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/Wandmalfarbe/pandoc-latex-template/compare/v3.0.0...v3.1.0

--- a/template-multi-file/common.latex
+++ b/template-multi-file/common.latex
@@ -90,6 +90,7 @@ $-- tables
 $--
 $if(tables)$
 \usepackage{longtable,booktabs,array}
+\newcounter{none} % for unnumbered tables
 $if(multirow)$
 \usepackage{multirow}
 $endif$
@@ -207,9 +208,9 @@ $-- Babel language support
 $--
 $if(lang)$
 \ifLuaTeX
-\usepackage[bidi=basic,shorthands=off,$for(babeloptions)$,$babeloptions$$endfor$]{babel}
+\usepackage[bidi=basic$if(shorthands)$$else$,shorthands=off$endif$$for(babeloptions)$,$babeloptions$$endfor$]{babel}
 \else
-\usepackage[bidi=default,shorthands=off,$for(babeloptions)$,$babeloptions$$endfor$]{babel}
+\usepackage[bidi=default$if(shorthands)$$else$,shorthands=off$endif$$for(babeloptions)$,$babeloptions$$endfor$]{babel}
 \fi
 $if(babel-lang)$
 $if(mainfont)$
@@ -257,6 +258,12 @@ $if(dir)$
   \newcommand{\LR}[1]{\beginL #1\endL}
   \newenvironment{RTL}{\beginR}{\endR}
   \newenvironment{LTR}{\beginL}{\endL}
+\fi
+\ifluatex
+  \newcommand{\RL}[1]{\bgroup\textdir TRT#1\egroup}
+  \newcommand{\LR}[1]{\bgroup\textdir TLT#1\egroup}
+  \newenvironment{RTL}{\textdir TRT\pardir TRT\bodydir TRT}{}
+  \newenvironment{LTR}{\textdir TLT\pardir TLT\bodydir TLT}{}
 \fi
 $endif$
 $--

--- a/template-multi-file/eisvogel.beamer
+++ b/template-multi-file/eisvogel.beamer
@@ -149,12 +149,12 @@ $after-header-includes.latex()$
 $hypersetup.latex()$
 
 $if(title)$
-\title$if(shorttitle)$[$shorttitle$]$endif${$title$$if(thanks)$\thanks{$thanks$}$endif$}
+\title$if(shorttitle)$[$shorttitle$]$endif${\texorpdfstring{$title$}{$title-meta$}$if(thanks)$\thanks{$thanks$}$endif$}
 $endif$
 $if(subtitle)$
-\subtitle$if(shortsubtitle)$[$shortsubtitle$]$endif${$subtitle$}
+\subtitle$if(shortsubtitle)$[$shortsubtitle$]$endif${\texorpdfstring{$subtitle$}{$subtitle-meta$}}
 $endif$
-\author$if(shortauthor)$[$shortauthor$]$endif${$for(author)$$author$$sep$ \and $endfor$}
+\author$if(shortauthor)$[$shortauthor$]$endif${\texorpdfstring{$for(author)$$author$$sep$ \and $endfor$}{$author-meta$}}
 \date$if(shortdate)$[$shortdate$]$endif${$date$}
 $if(institute)$
 \institute$if(shortinstitute)$[$shortinstitute$]$endif${$for(institute)$$institute$$sep$ \and $endfor$}

--- a/template-multi-file/eisvogel.latex
+++ b/template-multi-file/eisvogel.latex
@@ -78,7 +78,9 @@ $else$
 \usepackage[margin=2.5cm,includehead=true,includefoot=true,centering,$for(geometry)$$geometry$$sep$,$endfor$]{geometry}
 $endif$
 \usepackage{amsmath,amssymb}
-
+$if(cancel)$
+\usepackage{cancel}
+$endif$
 $if(titlepage-logo)$
 \usepackage[export]{adjustbox}
 \usepackage{graphicx}
@@ -105,6 +107,19 @@ $header-includes$
 $endfor$
 $after-header-includes.latex()$
 $hypersetup.latex()$
+$if(pdf-trailer-id)$
+
+\ifXeTeX
+\special{pdf:trailerid [ $pdf-trailer-id$ ]}
+\fi
+\ifPDFTeX
+\pdftrailerid{}
+\pdftrailer{/ID [ $pdf-trailer-id$ ]}
+\fi
+\ifLuaTeX
+\pdfvariable trailerid {[ $pdf-trailer-id$ ]}
+\fi
+$endif$
 
 $if(title)$
 \title{$title$$if(thanks)$\thanks{$thanks$}$endif$}
@@ -155,7 +170,9 @@ $if(toc-title)$
 $endif$
 {
 $if(colorlinks)$
-\hypersetup{linkcolor=$if(toccolor)$$toccolor$$else$$endif$}
+$if(toccolor)$
+\hypersetup{linkcolor=$toccolor$}
+$endif$
 $endif$
 \setcounter{tocdepth}{$toc-depth$}
 \tableofcontents


### PR DESCRIPTION
This resolves an incompatibility between Eisvogel and pandoc >= 3.8.2.1 because of the introduction of `\newcounter{none}` in [jgm/pandoc#11201](https://github.com/jgm/pandoc/issues/11201).