### PR TITLE
feat: add pandoc template for Epistemología e Historia de la Ciencia …

### DIFF
--- a/journals/epistemologia-historia-ciencia/Makefile
+++ b/journals/epistemologia-historia-ciencia/Makefile
@@ -1,0 +1,62 @@
+# Makefile for EHC Journal Template
+# Epistemología e Historia de la Ciencia
+
+PANDOC = pandoc
+LATEX = xelatex
+BIBER = biber
+
+# Source files
+EXAMPLE = ejemplo-articulo
+TEMPLATE = ehc-journal.latex
+BIB = referencias.bib
+
+# Output
+PDF = $(EXAMPLE).pdf
+TEX = $(EXAMPLE).tex
+
+.PHONY: all clean pdf tex
+
+all: pdf
+
+# Build PDF directly with citeproc (simpler)
+pdf-citeproc: $(EXAMPLE).md $(TEMPLATE) $(BIB)
+	$(PANDOC) $(EXAMPLE).md \
+		--template=$(TEMPLATE) \
+		--pdf-engine=xelatex \
+		--citeproc \
+		--bibliography=$(BIB) \
+		-o $(PDF)
+
+# Build TEX file for biblatex workflow
+tex: $(EXAMPLE).md $(TEMPLATE)
+	$(PANDOC) $(EXAMPLE).md \
+		--template=$(TEMPLATE) \
+		--biblatex \
+		-o $(TEX)
+
+# Full build with biblatex (for complex bibliographies)
+pdf: tex
+	$(LATEX) $(TEX)
+	$(BIBER) $(EXAMPLE)
+	$(LATEX) $(TEX)
+	$(LATEX) $(TEX)
+
+# Clean auxiliary files
+clean:
+	rm -f *.aux *.bbl *.bcf *.blg *.log *.out *.run.xml *.toc *.fdb_latexmk *.fls *.synctex.gz
+
+# Clean all generated files
+distclean: clean
+	rm -f $(PDF) $(TEX)
+
+# Help
+help:
+	@echo "Makefile for EHC Journal Template"
+	@echo ""
+	@echo "Targets:"
+	@echo "  pdf          - Build PDF with biblatex (default)"
+	@echo "  pdf-citeproc - Build PDF with citeproc (simpler)"
+	@echo "  tex          - Generate LaTeX file only"
+	@echo "  clean        - Remove auxiliary files"
+	@echo "  distclean    - Remove all generated files"
+	@echo "  help         - Show this help message"

--- a/journals/epistemologia-historia-ciencia/README.md
+++ b/journals/epistemologia-historia-ciencia/README.md
@@ -1,0 +1,179 @@
+# Plantilla LaTeX para "Epistemología e Historia de la Ciencia"
+
+Esta plantilla de Pandoc/LaTeX está diseñada específicamente para artículos académicos de la revista **Epistemología e Historia de la Ciencia**, especializada en filosofía e historia de la ciencia.
+
+## Características
+
+- **Idioma**: Español (con soporte para resúmenes bilingües español/inglés)
+- **Tipografía**: Palatino (cuerpo) y Helvetica (encabezados) para un aspecto académico clásico
+- **Colores**: Esquema basado en azul académico (`#003366`)
+- **Citas**: Soporte para BibLaTeX y NatBib
+- **Metadatos**: Campos específicos para información de la revista (volumen, número, ISSN, etc.)
+- **Autores**: Soporte para múltiples autores con afiliación, email y ORCID
+- **Fechas de publicación**: Campos para recibido, aceptado y publicado
+
+## Uso
+
+### Requisitos
+
+- Pandoc 2.x o superior
+- Una distribución de LaTeX (TeX Live, MiKTeX, etc.)
+- BibLaTeX (si se usa bibliografía)
+
+### Comando básico
+
+```bash
+pandoc ejemplo-articulo.md \
+  --template=ehc-journal.latex \
+  --pdf-engine=xelatex \
+  --citeproc \
+  -o articulo.pdf
+```
+
+### Con bibliografía BibLaTeX
+
+```bash
+pandoc ejemplo-articulo.md \
+  --template=ehc-journal.latex \
+  --pdf-engine=xelatex \
+  --biblatex \
+  -o articulo.tex
+
+# Luego compilar con:
+xelatex articulo.tex
+biber articulo
+xelatex articulo.tex
+xelatex articulo.tex
+```
+
+### Alternativa con Citeproc
+
+```bash
+pandoc ejemplo-articulo.md \
+  --template=ehc-journal.latex \
+  --pdf-engine=xelatex \
+  --citeproc \
+  --bibliography=referencias.bib \
+  -o articulo.pdf
+```
+
+## Metadatos YAML
+
+### Información del artículo
+
+```yaml
+---
+title: "Título del artículo"
+shorttitle: "Título corto para encabezado"
+subtitle: "Subtítulo opcional"
+---
+```
+
+### Autores
+
+Formato simple:
+```yaml
+author:
+  - Nombre del Autor
+```
+
+Formato completo:
+```yaml
+author:
+  - name: Nombre Completo
+    affiliation: Universidad, País
+    email: correo@universidad.edu
+    orcid: 0000-0001-2345-6789
+```
+
+### Metadatos de la revista
+
+```yaml
+volume: 9
+number: 2
+year: 2024
+pages: 45-78
+issn: 1234-5678
+```
+
+### Fechas de publicación
+
+```yaml
+received: 15 de marzo de 2024
+accepted: 22 de junio de 2024
+published: 1 de octubre de 2024
+```
+
+### Resúmenes y palabras clave
+
+```yaml
+abstract: |
+  Resumen en español del artículo...
+
+keywords:
+  - palabra clave 1
+  - palabra clave 2
+
+abstract-en: |
+  English abstract of the article...
+
+keywords-en:
+  - keyword 1
+  - keyword 2
+```
+
+### Bibliografía
+
+```yaml
+bibliography: referencias.bib
+biblatex: true
+biblio-style: authoryear
+```
+
+### Opciones adicionales
+
+```yaml
+lang: es                    # Idioma del documento
+numbersections: true        # Numerar secciones
+toc: false                  # Tabla de contenidos
+linestretch: 1.15           # Interlineado
+geometry:                   # Márgenes personalizados
+  - top=3cm
+  - bottom=3cm
+  - left=2.5cm
+  - right=2.5cm
+```
+
+## Personalización de encabezados y pies de página
+
+```yaml
+header-left: "Texto izquierdo del encabezado"
+header-right: "Texto derecho del encabezado"
+footer-left: "Texto izquierdo del pie"
+```
+
+## Estructura del documento
+
+La plantilla genera automáticamente:
+
+1. **Encabezado de revista**: Con nombre de la revista, volumen, número y ISSN
+2. **Título y autores**: Con afiliaciones, emails y ORCIDs
+3. **Fechas de publicación**: Recibido, aceptado, publicado
+4. **Resumen bilingüe**: Español e inglés con palabras clave
+5. **Cuerpo del artículo**: Con formato académico apropiado
+6. **Referencias**: Según el estilo bibliográfico elegido
+
+## Archivos incluidos
+
+- `ehc-journal.latex` - Plantilla principal de LaTeX
+- `ejemplo-articulo.md` - Ejemplo de artículo en Markdown
+- `referencias.bib` - Ejemplo de archivo de bibliografía
+- `README.md` - Este archivo de documentación
+
+## Licencia
+
+Esta plantilla está basada en la plantilla Eisvogel y se distribuye bajo los mismos términos de licencia BSD de 3 cláusulas.
+
+## Soporte
+
+Para reportar problemas o sugerir mejoras, por favor crea un issue en el repositorio de GitHub.

--- a/journals/epistemologia-historia-ciencia/ehc-journal.latex
+++ b/journals/epistemologia-historia-ciencia/ehc-journal.latex
@@ -1,0 +1,349 @@
+%%
+% LaTeX Template for "Epistemología e Historia de la Ciencia" Journal
+%
+% Based on the Eisvogel pandoc LaTeX template
+% https://github.com/Wandmalfarbe/pandoc-latex-template
+%
+% Customized for academic philosophy and history of science papers
+%%
+
+\PassOptionsToPackage{unicode$for(hyperrefoptions)$,$hyperrefoptions$$endfor$}{hyperref}
+\PassOptionsToPackage{hyphens}{url}
+$if(colorlinks)$
+\PassOptionsToPackage{dvipsnames,svgnames,x11names}{xcolor}
+$endif$
+
+\documentclass[
+  spanish,
+$if(fontsize)$
+  $fontsize$,
+$else$
+  11pt,
+$endif$
+$if(papersize)$
+  $papersize$paper,
+$else$
+  a4paper,
+$endif$
+$for(classoption)$
+  $classoption$$sep$,
+$endfor$
+  captions=tableheading
+]{scrartcl}
+
+% Essential packages
+\usepackage{amsmath,amssymb}
+\usepackage{xcolor}
+\usepackage{graphicx}
+
+% Spanish language support
+\usepackage[spanish,es-tabla]{babel}
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+
+% Typography - Use Palatino for a classic academic look
+\usepackage{mathpazo}
+\usepackage[scaled=0.95]{helvet}
+\usepackage{courier}
+\linespread{1.05}
+
+% Page geometry
+$if(geometry)$
+\usepackage[$for(geometry)$$geometry$$sep$,$endfor$]{geometry}
+$else$
+\usepackage[
+  top=2.5cm,
+  bottom=2.5cm,
+  left=2.5cm,
+  right=2.5cm,
+  includehead=true,
+  includefoot=true
+]{geometry}
+$endif$
+
+% Hyperlinks
+\usepackage{hyperref}
+\hypersetup{
+  pdftitle={$if(title)$$title$$endif$},
+  pdfauthor={$for(author)$$author$$sep$, $endfor$},
+  pdfkeywords={$for(keywords)$$keywords$$sep$, $endfor$},
+  colorlinks=true,
+  linkcolor={ehc-blue},
+  citecolor={ehc-green},
+  urlcolor={ehc-blue},
+  pdfcreator={LaTeX via pandoc - EHC Journal Template}
+}
+
+% Journal colors
+\definecolor{ehc-blue}{RGB}{0,51,102}
+\definecolor{ehc-green}{RGB}{0,102,51}
+\definecolor{ehc-gray}{RGB}{102,102,102}
+\definecolor{ehc-lightgray}{RGB}{240,240,240}
+\definecolor{ehc-rule}{RGB}{0,51,102}
+
+% Captions
+\usepackage[
+  font={small,stretch=1.1},
+  labelfont={bf,color=ehc-blue},
+  textfont={color=ehc-gray},
+  position=bottom,
+  skip=4mm,
+  singlelinecheck=false,
+  justification=justified
+]{caption}
+\setcapindent{0em}
+
+% Blockquotes - styled for philosophical texts
+\usepackage{mdframed}
+\definecolor{blockquote-border}{RGB}{0,51,102}
+\definecolor{blockquote-text}{RGB}{64,64,64}
+\newmdenv[
+  rightline=false,
+  bottomline=false,
+  topline=false,
+  linewidth=2pt,
+  linecolor=blockquote-border,
+  skipabove=\parskip,
+  skipbelow=\parskip,
+  innerleftmargin=1em,
+  innerrightmargin=0em
+]{customblockquote}
+\renewenvironment{quote}{%
+  \begin{customblockquote}%
+  \list{}{\rightmargin=0em\leftmargin=0em}%
+  \item\relax\color{blockquote-text}\small\itshape\ignorespaces
+}{%
+  \unskip\unskip\endlist\end{customblockquote}%
+}
+
+% Section headings
+\addtokomafont{disposition}{\normalfont\color{ehc-blue}\bfseries}
+\addtokomafont{section}{\Large}
+\addtokomafont{subsection}{\large}
+\addtokomafont{subsubsection}{\normalsize}
+
+% Paragraph settings
+\setlength{\parindent}{1.5em}
+\setlength{\parskip}{0pt plus 1pt}
+\setlength{\emergencystretch}{3em}
+
+% Section numbering
+$if(numbersections)$
+\setcounter{secnumdepth}{$if(secnumdepth)$$secnumdepth$$else$3$endif$}
+$else$
+\setcounter{secnumdepth}{3}
+$endif$
+
+% Tables
+$if(tables)$
+\usepackage{longtable,booktabs,array}
+\definecolor{table-row-color}{HTML}{F5F5F5}
+\definecolor{table-rule-color}{RGB}{0,51,102}
+\arrayrulecolor{table-rule-color}
+\setlength\heavyrulewidth{0.4ex}
+\renewcommand{\arraystretch}{1.3}
+$endif$
+
+% Lists
+\usepackage{enumitem}
+\setlist[itemize]{topsep=0pt,itemsep=2pt,parsep=0pt}
+\setlist[enumerate]{topsep=0pt,itemsep=2pt,parsep=0pt}
+
+% Footnotes - important for philosophical texts
+\usepackage[hang,flushmargin,bottom,multiple]{footmisc}
+\setlength{\footnotemargin}{0.8em}
+\setlength{\footnotesep}{\baselineskip}
+\setlength{\skip\footins}{1cm}
+\renewcommand{\footnoterule}{%
+  \kern -3pt
+  {\color{ehc-blue}\hrule width 2in height 0.4pt}
+  \kern 2.6pt
+}
+
+% Bibliography support
+$if(natbib)$
+\usepackage[$natbiboptions$]{natbib}
+\bibliographystyle{$if(biblio-style)$$biblio-style$$else$plainnat$endif$}
+$endif$
+$if(biblatex)$
+\usepackage[$if(biblio-style)$style=$biblio-style$,$endif$$for(biblatexoptions)$$biblatexoptions$$sep$,$endfor$]{biblatex}
+$for(bibliography)$
+\addbibresource{$bibliography$}
+$endfor$
+$endif$
+
+% Quotes package for proper Spanish quotation marks
+\usepackage{csquotes}
+
+% Header includes
+$for(header-includes)$
+$header-includes$
+$endfor$
+
+% Header and footer
+\usepackage[headsepline,footsepline]{scrlayer-scrpage}
+\newpairofpagestyles{ehc-header-footer}{
+  \clearpairofpagestyles
+  \ihead*{\small\textit{$if(header-left)$$header-left$$else$Epistemología e Historia de la Ciencia$endif$}}
+  \chead*{}
+  \ohead*{\small\textit{$if(header-right)$$header-right$$else$$if(shorttitle)$$shorttitle$$else$$title$$endif$$endif$}}
+  \ifoot*{\small$if(footer-left)$$footer-left$$else$$if(volume)$Vol. $volume$$if(number)$($number$)$endif$$if(year)$, $year$$endif$$endif$$endif$}
+  \cfoot*{}
+  \ofoot*{\small\thepage}
+  \addtokomafont{pageheadfoot}{\upshape\color{ehc-gray}}
+  \setkomafont{headsepline}{\color{ehc-blue}}
+  \setkomafont{footsepline}{\color{ehc-blue}}
+}
+\pagestyle{ehc-header-footer}
+
+% Title information
+\usepackage{titling}
+\title{$if(title)$$title$$endif$}
+\author{$for(author)$$author$$sep$, $endfor$}
+\date{$if(date)$$date$$endif$}
+
+% Custom title page command
+\newcommand{\ehcmaketitle}{%
+  \begin{center}
+    % Journal header
+    {\color{ehc-blue}\rule{\textwidth}{1pt}}
+    \vspace{0.3cm}
+
+    {\Large\scshape\color{ehc-blue} Epistemología e Historia de la Ciencia}
+
+    \vspace{0.2cm}
+
+    $if(volume)$
+    {\small Vol. $volume$$if(number)$, N.º $number$$endif$$if(year)$ ($year$)$endif$$if(pages)$, pp. $pages$$endif$}
+    $endif$
+
+    $if(issn)$
+    {\small ISSN: $issn$}
+    $endif$
+
+    \vspace{0.2cm}
+    {\color{ehc-blue}\rule{\textwidth}{1pt}}
+
+    \vspace{1.5cm}
+
+    % Article title
+    {\LARGE\bfseries\color{ehc-blue} $title$\par}
+
+    $if(subtitle)$
+    \vspace{0.5cm}
+    {\Large\color{ehc-gray} $subtitle$\par}
+    $endif$
+
+    \vspace{1cm}
+
+    % Authors
+    $for(author)$
+    $if(author.name)$
+    {\large\bfseries $author.name$}\\
+    $if(author.affiliation)$
+    {\small\color{ehc-gray} $author.affiliation$}\\
+    $endif$
+    $if(author.email)$
+    {\small\color{ehc-blue}\href{mailto:$author.email$}{$author.email$}}\\
+    $endif$
+    $if(author.orcid)$
+    {\small\color{ehc-gray} ORCID: \href{https://orcid.org/$author.orcid$}{$author.orcid$}}\\
+    $endif$
+    \vspace{0.3cm}
+    $else$
+    {\large\bfseries $author$}\\
+    \vspace{0.3cm}
+    $endif$
+    $endfor$
+
+    \vspace{0.5cm}
+
+    $if(received)$
+    {\small\color{ehc-gray} Recibido: $received$$if(accepted)$ | Aceptado: $accepted$$endif$$if(published)$ | Publicado: $published$$endif$}
+    $endif$
+
+  \end{center}
+
+  \vspace{1cm}
+
+  % Abstract
+  $if(abstract)$
+  \begin{center}
+  \begin{minipage}{0.9\textwidth}
+    \noindent{\small\bfseries\color{ehc-blue} Resumen}\\[0.3em]
+    {\small $abstract$}
+
+    $if(keywords)$
+    \vspace{0.5em}
+    \noindent{\small\bfseries\color{ehc-blue} Palabras clave:} {\small $for(keywords)$$keywords$$sep$; $endfor$}
+    $endif$
+  \end{minipage}
+  \end{center}
+  $endif$
+
+  % English abstract if provided
+  $if(abstract-en)$
+  \vspace{0.5cm}
+  \begin{center}
+  \begin{minipage}{0.9\textwidth}
+    \noindent{\small\bfseries\color{ehc-blue} Abstract}\\[0.3em]
+    {\small $abstract-en$}
+
+    $if(keywords-en)$
+    \vspace{0.5em}
+    \noindent{\small\bfseries\color{ehc-blue} Keywords:} {\small $for(keywords-en)$$keywords-en$$sep$; $endfor$}
+    $endif$
+  \end{minipage}
+  \end{center}
+  $endif$
+
+  \vspace{1cm}
+  {\color{ehc-blue}\rule{\textwidth}{0.5pt}}
+  \vspace{0.5cm}
+}
+
+\begin{document}
+
+% Generate title page
+\ehcmaketitle
+
+$for(include-before)$
+$include-before$
+$endfor$
+
+% Table of contents (optional)
+$if(toc)$
+{
+\hypersetup{linkcolor=ehc-blue}
+\setcounter{tocdepth}{$if(toc-depth)$$toc-depth$$else$3$endif$}
+\renewcommand*\contentsname{Índice}
+\tableofcontents
+\newpage
+}
+$endif$
+
+% Line stretch for body
+$if(linestretch)$
+\setstretch{$linestretch$}
+$endif$
+
+% Main content
+$body$
+
+% Bibliography
+$if(natbib)$
+$if(bibliography)$
+\renewcommand\refname{Referencias}
+\bibliography{$for(bibliography)$$bibliography$$sep$,$endfor$}
+$endif$
+$endif$
+$if(biblatex)$
+\renewcommand\bibname{Referencias}
+\printbibliography$if(biblio-title)$[title=$biblio-title$]$endif$
+$endif$
+
+$for(include-after)$
+$include-after$
+$endfor$
+
+\end{document}

--- a/journals/epistemologia-historia-ciencia/ejemplo-articulo.md
+++ b/journals/epistemologia-historia-ciencia/ejemplo-articulo.md
@@ -1,0 +1,170 @@
+---
+title: "La estructura de las revoluciones científicas y su impacto en la filosofía de la ciencia contemporánea"
+shorttitle: "Revoluciones científicas"
+subtitle: "Un análisis crítico del paradigma kuhniano"
+
+author:
+  - name: María Elena García López
+    affiliation: Universidad Nacional de Córdoba, Argentina
+    email: me.garcia@unc.edu.ar
+    orcid: 0000-0001-2345-6789
+  - name: Juan Carlos Rodríguez Pérez
+    affiliation: Universidad de Buenos Aires, Argentina
+    email: jc.rodriguez@uba.ar
+    orcid: 0000-0002-3456-7890
+
+# Journal metadata
+volume: 9
+number: 2
+year: 2024
+pages: 45-78
+issn: 1234-5678
+
+# Dates
+received: 15 de marzo de 2024
+accepted: 22 de junio de 2024
+published: 1 de octubre de 2024
+
+# Abstracts
+abstract: |
+  En este artículo examinamos el legado de Thomas Kuhn y su obra *La estructura de las revoluciones científicas* (1962) en el desarrollo de la filosofía de la ciencia contemporánea. Argumentamos que, a pesar de las numerosas críticas recibidas, el concepto de paradigma y la noción de inconmensurabilidad siguen siendo herramientas conceptuales valiosas para comprender el cambio científico. Analizamos las principales objeciones planteadas por Popper, Lakatos y Feyerabend, y proponemos una lectura renovada del pensamiento kuhniano que integra los desarrollos más recientes en historia y sociología de la ciencia.
+
+keywords:
+  - Kuhn
+  - paradigma
+  - inconmensurabilidad
+  - cambio científico
+  - filosofía de la ciencia
+
+abstract-en: |
+  In this paper, we examine the legacy of Thomas Kuhn and his work *The Structure of Scientific Revolutions* (1962) in the development of contemporary philosophy of science. We argue that, despite numerous criticisms, the concept of paradigm and the notion of incommensurability remain valuable conceptual tools for understanding scientific change. We analyze the main objections raised by Popper, Lakatos, and Feyerabend, and propose a renewed reading of Kuhnian thought that integrates the most recent developments in the history and sociology of science.
+
+keywords-en:
+  - Kuhn
+  - paradigm
+  - incommensurability
+  - scientific change
+  - philosophy of science
+
+# Bibliography
+bibliography: referencias.bib
+biblatex: true
+biblio-style: authoryear
+
+# Document settings
+lang: es
+numbersections: true
+toc: false
+---
+
+# Introducción
+
+La publicación de *La estructura de las revoluciones científicas* de Thomas Kuhn en 1962 marcó un punto de inflexión en la filosofía de la ciencia del siglo XX. Su caracterización del desarrollo científico como una alternancia entre períodos de «ciencia normal» y «revoluciones científicas» desafió profundamente la imagen acumulativa y progresiva de la ciencia que había dominado el pensamiento filosófico desde el positivismo lógico.
+
+> La ciencia normal, la actividad en que, inevitablemente, la mayoría de los científicos consumen casi todo su tiempo, se predica suponiendo que la comunidad científica sabe cómo es el mundo. [@kuhn1962, p. 5]
+
+En este trabajo nos proponemos analizar críticamente el impacto del pensamiento kuhniano en tres dimensiones fundamentales:
+
+1. La reconceptualización de la racionalidad científica
+2. El problema de la inconmensurabilidad entre teorías
+3. Las implicaciones para una epistemología histórica de la ciencia
+
+## Contexto histórico-filosófico
+
+Para comprender la magnitud de la intervención kuhniana, es necesario situarla en el contexto de la filosofía de la ciencia de mediados del siglo XX. El panorama estaba dominado por dos tradiciones principales:
+
+- **El empirismo lógico**: representado por el Círculo de Viena y su programa de reconstrucción racional de las teorías científicas.
+- **El racionalismo crítico**: desarrollado por Karl Popper, con su énfasis en la falsabilidad como criterio de demarcación.
+
+Ambas tradiciones compartían, sin embargo, una imagen fundamentalmente acumulativa del progreso científico, según la cual el conocimiento científico crece de manera continua a través de la confirmación (en el caso del empirismo lógico) o la refutación (en el caso de Popper) de hipótesis.
+
+# El concepto de paradigma
+
+El concepto de paradigma constituye el núcleo del análisis kuhniano. A pesar de las conocidas ambigüedades terminológicas señaladas por Masterman [-@masterman1970], podemos identificar al menos dos sentidos fundamentales:
+
+## Paradigma como matriz disciplinar
+
+En su sentido amplio, un paradigma comprende el conjunto de compromisos compartidos por una comunidad científica, incluyendo:
+
+1. Generalizaciones simbólicas
+2. Modelos ontológicos
+3. Valores epistémicos
+4. Ejemplares
+
+### Generalizaciones simbólicas
+
+Las generalizaciones simbólicas son las expresiones formales que funcionan como leyes o definiciones dentro del paradigma. Por ejemplo, en la mecánica newtoniana:
+
+$$F = ma$$
+
+Esta ecuación no solo describe una relación empírica, sino que define parcialmente los conceptos de fuerza, masa y aceleración dentro del marco conceptual de la física clásica.
+
+### Valores epistémicos
+
+Los valores que guían la elección teórica en ciencia incluyen:
+
+| Valor | Descripción |
+|-------|-------------|
+| Precisión | Concordancia con experimentos y observaciones |
+| Consistencia | Coherencia interna y externa |
+| Alcance | Amplitud de consecuencias |
+| Simplicidad | Organización de fenómenos diversos |
+| Fecundidad | Capacidad de generar nuevos hallazgos |
+
+Table: Valores epistémicos según Kuhn (1977)
+
+## Paradigma como ejemplar
+
+En su sentido restringido, el paradigma designa los ejemplos compartidos de resolución de problemas que sirven como modelos para la práctica científica. Estos ejemplares son cruciales para la transmisión del conocimiento tácito dentro de una tradición científica.
+
+# El problema de la inconmensurabilidad
+
+Quizás ningún aspecto del pensamiento kuhniano ha generado mayor controversia que la tesis de la inconmensurabilidad. Según esta tesis, los paradigmas sucesivos son, en cierto sentido, incomparables.
+
+> Quienes proponen los paradigmas en competencia practican sus profesiones en mundos diferentes. [...] Ambos miran al mundo y lo que miran no ha cambiado. Pero en algunos campos ven cosas diferentes. [@kuhn1962, p. 150]
+
+## Tipos de inconmensurabilidad
+
+Podemos distinguir tres formas de inconmensurabilidad en la obra de Kuhn:
+
+1. **Semántica**: cambio en el significado de los términos teóricos
+2. **Metodológica**: variación en los estándares de evaluación
+3. **Perceptual**: diferencias en la observación del mundo
+
+### La respuesta a las críticas
+
+Las críticas de Popper y otros autores llevaron a Kuhn a precisar y moderar su posición. En sus trabajos posteriores [@kuhn1983], Kuhn distingue claramente entre inconmensurabilidad e incomparabilidad:
+
+> Afirmar que dos teorías son inconmensurables significa afirmar que no hay lenguaje, neutral o de otro tipo, al que ambas teorías puedan traducirse sin resto o pérdida. [...] La mayoría de los términos comunes a las dos teorías funcionan de la misma manera en ambas.
+
+# Implicaciones para la filosofía de la ciencia contemporánea
+
+El legado kuhniano se manifiesta en múltiples desarrollos contemporáneos:
+
+## Giro historicista
+
+El trabajo de Kuhn inauguró lo que se ha denominado el «giro historicista» en filosofía de la ciencia, que enfatiza:
+
+- La relevancia de la historia para la epistemología
+- El carácter social del conocimiento científico
+- La importancia de las prácticas científicas concretas
+
+## Estudios sociales de la ciencia
+
+El programa fuerte de la sociología del conocimiento científico [@bloor1976] radicalizó algunos aspectos del pensamiento kuhniano, aunque Kuhn mismo se distanció de estas interpretaciones.
+
+# Conclusiones
+
+A más de sesenta años de su publicación, *La estructura de las revoluciones científicas* sigue siendo una obra fundamental para la reflexión filosófica sobre la ciencia. Si bien muchas de sus tesis específicas han sido revisadas o abandonadas, su contribución más perdurable consiste en haber demostrado la inseparabilidad de las dimensiones cognitivas, sociales e históricas del conocimiento científico.
+
+La filosofía de la ciencia posterior a Kuhn no puede ignorar:
+
+1. El carácter socialmente situado de la práctica científica
+2. La historicidad de los estándares de racionalidad
+3. La complejidad del cambio teórico
+
+En este sentido, el pensamiento kuhniano sigue ofreciendo recursos conceptuales valiosos para comprender la ciencia como una empresa humana, falible pero racionalmente orientada hacia la comprensión del mundo.
+
+# Agradecimientos
+
+Los autores agradecen los comentarios de dos evaluadores anónimos que contribuyeron a mejorar sustancialmente este trabajo. Esta investigación fue financiada por el CONICET (PIP 2022-0123).

--- a/journals/epistemologia-historia-ciencia/referencias.bib
+++ b/journals/epistemologia-historia-ciencia/referencias.bib
@@ -1,0 +1,87 @@
+@book{kuhn1962,
+  author    = {Kuhn, Thomas S.},
+  title     = {The Structure of Scientific Revolutions},
+  publisher = {University of Chicago Press},
+  year      = {1962},
+  address   = {Chicago}
+}
+
+@incollection{masterman1970,
+  author    = {Masterman, Margaret},
+  title     = {The Nature of a Paradigm},
+  booktitle = {Criticism and the Growth of Knowledge},
+  editor    = {Lakatos, Imre and Musgrave, Alan},
+  publisher = {Cambridge University Press},
+  year      = {1970},
+  pages     = {59--89},
+  address   = {Cambridge}
+}
+
+@book{popper1963,
+  author    = {Popper, Karl R.},
+  title     = {Conjectures and Refutations: The Growth of Scientific Knowledge},
+  publisher = {Routledge and Kegan Paul},
+  year      = {1963},
+  address   = {London}
+}
+
+@book{lakatos1978,
+  author    = {Lakatos, Imre},
+  title     = {The Methodology of Scientific Research Programmes},
+  publisher = {Cambridge University Press},
+  year      = {1978},
+  address   = {Cambridge}
+}
+
+@book{feyerabend1975,
+  author    = {Feyerabend, Paul},
+  title     = {Against Method: Outline of an Anarchistic Theory of Knowledge},
+  publisher = {New Left Books},
+  year      = {1975},
+  address   = {London}
+}
+
+@incollection{kuhn1977,
+  author    = {Kuhn, Thomas S.},
+  title     = {Objectivity, Value Judgment, and Theory Choice},
+  booktitle = {The Essential Tension},
+  publisher = {University of Chicago Press},
+  year      = {1977},
+  pages     = {320--339},
+  address   = {Chicago}
+}
+
+@incollection{kuhn1983,
+  author    = {Kuhn, Thomas S.},
+  title     = {Commensurability, Comparability, Communicability},
+  booktitle = {PSA 1982},
+  editor    = {Asquith, P. D. and Nickles, T.},
+  publisher = {Philosophy of Science Association},
+  year      = {1983},
+  pages     = {669--688},
+  address   = {East Lansing}
+}
+
+@book{bloor1976,
+  author    = {Bloor, David},
+  title     = {Knowledge and Social Imagery},
+  publisher = {Routledge and Kegan Paul},
+  year      = {1976},
+  address   = {London}
+}
+
+@book{hacking1983,
+  author    = {Hacking, Ian},
+  title     = {Representing and Intervening: Introductory Topics in the Philosophy of Natural Science},
+  publisher = {Cambridge University Press},
+  year      = {1983},
+  address   = {Cambridge}
+}
+
+@book{laudan1977,
+  author    = {Laudan, Larry},
+  title     = {Progress and Its Problems: Toward a Theory of Scientific Growth},
+  publisher = {University of California Press},
+  year      = {1977},
+  address   = {Berkeley}
+}


### PR DESCRIPTION
…journal

Add a customized LaTeX/Pandoc template for the academic journal "Epistemología e Historia de la Ciencia" (philosophy and history of science).

Template features:
- Spanish language defaults with babel support
- Classic academic typography (Palatino/Helvetica)
- Professional blue color scheme (#003366)
- Custom title page with journal metadata
- Support for bilingual abstracts (Spanish/English)
- Author fields with affiliation, email, and ORCID
- Publication date tracking (received/accepted/published)
- BibLaTeX and NatBib bibliography support
- Styled blockquotes for philosophical texts
- Academic footnote formatting

Includes example article and Makefile for easy compilation.