### PR TITLE
feat: allow users to customize paragraph indentation

### DIFF
--- a/template-multi-file/eisvogel-added.latex
+++ b/template-multi-file/eisvogel-added.latex
@@ -136,13 +136,6 @@ $endif$
 $endif$
 
 %
-% remove paragraph indentation
-%
-\setlength{\parindent}{0pt}
-\setlength{\parskip}{6pt plus 2pt minus 1pt}
-\setlength{\emergencystretch}{3em}  % prevent overfull lines
-
-%
 %
 % Listings
 %


### PR DESCRIPTION
Remove hardcoded `\parindent` and `\parskip` settings in the template. Which allows users to define their own custom paragraph indentation and spacing in headers and default files.

fix #452