### PR TITLE
fix: change SEDOPTION in release.sh to index

### DIFF
--- a/tools/release.sh
+++ b/tools/release.sh
@@ -16,40 +16,39 @@ mkdir "${distFolderName}/${archiveFolderName}"
 # see https://stackoverflow.com/a/66763713
 SEDOPTION=
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  SEDOPTION="-i \x27\x27"
+  SEDOPTION=(-i '')
 else
-  SEDOPTION="-i"
+  SEDOPTION=(-i)
 fi
 
-echo $SEDOPTION
+echo "${SEDOPTION[@]}"
 
 # create single template file for latex
 cp "template-multi-file/eisvogel.latex" "${distFolderName}/eisvogel.latex"
 
 # replace partials (latex)
-sed -e '/\$fonts\.latex()\$/ {' -e 'r template-multi-file/fonts.latex' -e 'd' -e '}' $SEDOPTION "${distFolderName}/eisvogel.latex"
-sed -e '/\$font-settings\.latex()\$/ {' -e 'r template-multi-file/font-settings.latex' -e 'd' -e '}' $SEDOPTION "${distFolderName}/eisvogel.latex"
-sed -e '/\$common\.latex()\$/ {' -e 'r template-multi-file/common.latex' -e 'd' -e '}' $SEDOPTION "${distFolderName}/eisvogel.latex"
-sed -e '/\$document-metadata\.latex()\$/ {' -e 'r template-multi-file/document-metadata.latex' -e 'd' -e '}' $SEDOPTION "${distFolderName}/eisvogel.latex"
-sed -e '/\$eisvogel-added\.latex()\$/ {' -e 'r template-multi-file/eisvogel-added.latex' -e 'd' -e '}' $SEDOPTION "${distFolderName}/eisvogel.latex"
-sed -e '/\$eisvogel-title-page\.latex()\$/ {' -e 'r template-multi-file/eisvogel-title-page.latex' -e 'd' -e '}' $SEDOPTION "${distFolderName}/eisvogel.latex"
-sed -e '/\$after-header-includes\.latex()\$/ {' -e 'r template-multi-file/after-header-includes.latex' -e 'd' -e '}' $SEDOPTION "${distFolderName}/eisvogel.latex"
-sed -e '/\$hypersetup\.latex()\$/ {' -e 'r template-multi-file/hypersetup.latex' -e 'd' -e '}' $SEDOPTION "${distFolderName}/eisvogel.latex"
-sed -e '/\$passoptions\.latex()\$/ {' -e 'r template-multi-file/passoptions.latex' -e 'd' -e '}' $SEDOPTION "${distFolderName}/eisvogel.latex"
+sed -e '/\$fonts\.latex()\$/ {' -e 'r template-multi-file/fonts.latex' -e 'd' -e '}' "${SEDOPTION[@]}" "${distFolderName}/eisvogel.latex"
+sed -e '/\$font-settings\.latex()\$/ {' -e 'r template-multi-file/font-settings.latex' -e 'd' -e '}' "${SEDOPTION[@]}" "${distFolderName}/eisvogel.latex"
+sed -e '/\$common\.latex()\$/ {' -e 'r template-multi-file/common.latex' -e 'd' -e '}' "${SEDOPTION[@]}" "${distFolderName}/eisvogel.latex"
+sed -e '/\$document-metadata\.latex()\$/ {' -e 'r template-multi-file/document-metadata.latex' -e 'd' -e '}' "${SEDOPTION[@]}" "${distFolderName}/eisvogel.latex"
+sed -e '/\$eisvogel-added\.latex()\$/ {' -e 'r template-multi-file/eisvogel-added.latex' -e 'd' -e '}' "${SEDOPTION[@]}" "${distFolderName}/eisvogel.latex"
+sed -e '/\$eisvogel-title-page\.latex()\$/ {' -e 'r template-multi-file/eisvogel-title-page.latex' -e 'd' -e '}' "${SEDOPTION[@]}" "${distFolderName}/eisvogel.latex"
+sed -e '/\$after-header-includes\.latex()\$/ {' -e 'r template-multi-file/after-header-includes.latex' -e 'd' -e '}' "${SEDOPTION[@]}" "${distFolderName}/eisvogel.latex"
+sed -e '/\$hypersetup\.latex()\$/ {' -e 'r template-multi-file/hypersetup.latex' -e 'd' -e '}' "${SEDOPTION[@]}" "${distFolderName}/eisvogel.latex"
+sed -e '/\$passoptions\.latex()\$/ {' -e 'r template-multi-file/passoptions.latex' -e 'd' -e '}' "${SEDOPTION[@]}" "${distFolderName}/eisvogel.latex"
 
 # create single template file for beamer
 cp "template-multi-file/eisvogel.beamer" "${distFolderName}/eisvogel.beamer"
 
 # replace partials (beamer)
-sed -e '/\$fonts\.latex()\$/ {' -e 'r template-multi-file/fonts.latex' -e 'd' -e '}' $SEDOPTION "${distFolderName}/eisvogel.beamer"
-sed -e '/\$font-settings\.latex()\$/ {' -e 'r template-multi-file/font-settings.latex' -e 'd' -e '}' $SEDOPTION "${distFolderName}/eisvogel.beamer"
-sed -e '/\$common\.latex()\$/ {' -e 'r template-multi-file/common.latex' -e 'd' -e '}' $SEDOPTION "${distFolderName}/eisvogel.beamer"
+sed -e '/\$fonts\.latex()\$/ {' -e 'r template-multi-file/fonts.latex' -e 'd' -e '}' "${SEDOPTION[@]}" "${distFolderName}/eisvogel.beamer"
+sed -e '/\$font-settings\.latex()\$/ {' -e 'r template-multi-file/font-settings.latex' -e 'd' -e '}' "${SEDOPTION[@]}" "${distFolderName}/eisvogel.beamer"
+sed -e '/\$common\.latex()\$/ {' -e 'r template-multi-file/common.latex' -e 'd' -e '}' "${SEDOPTION[@]}" "${distFolderName}/eisvogel.beamer"
 # The beamer template has no eisvogel block $eisvogel-added.latex()$
 # The beamer template has no eisvogel titlepage $eisvogel-titlepage.latex()$
-sed -e '/\$after-header-includes\.latex()\$/ {' -e 'r template-multi-file/after-header-includes.latex' -e 'd' -e '}' $SEDOPTION "${distFolderName}/eisvogel.beamer"
-sed -e '/\$hypersetup\.latex()\$/ {' -e 'r template-multi-file/hypersetup.latex' -e 'd' -e '}' $SEDOPTION "${distFolderName}/eisvogel.beamer"
-sed -e '/\$passoptions\.latex()\$/ {' -e 'r template-multi-file/passoptions.latex' -e 'd' -e '}' $SEDOPTION "${distFolderName}/eisvogel.beamer"
-
+sed -e '/\$after-header-includes\.latex()\$/ {' -e 'r template-multi-file/after-header-includes.latex' -e 'd' -e '}' "${SEDOPTION[@]}" "${distFolderName}/eisvogel.beamer"
+sed -e '/\$hypersetup\.latex()\$/ {' -e 'r template-multi-file/hypersetup.latex' -e 'd' -e '}' "${SEDOPTION[@]}" "${distFolderName}/eisvogel.beamer"
+sed -e '/\$passoptions\.latex()\$/ {' -e 'r template-multi-file/passoptions.latex' -e 'd' -e '}' "${SEDOPTION[@]}" "${distFolderName}/eisvogel.beamer"
 
 # create folder for the release eisvogel (ZIP and tar.gz)
 cp -r "examples" "${archiveFolder}/examples"
@@ -60,7 +59,6 @@ cp "icon.png" "${archiveFolder}/icon.png"
 cp "LICENSE" "${archiveFolder}/LICENSE"
 cp "README.md" "${archiveFolder}/README.md"
 cp "CHANGELOG.md" "${archiveFolder}/CHANGELOG.md"
-
 
 cd dist
 


### PR DESCRIPTION
Addresses #409

## Context/Explanation
As release.sh already notes sed behaves differently on MacOS. I have therefore worked to find a solution that should operate on both Mac and GNU platforms. A bit of exploration shows that using a bash index appears to work, but it does mean that the index has to be expanded in each use. This means that it looks like a more substantial change than it actually is. I have tested this on the recent release of MacOS and also in the latest Ubuntu Docker container, and it appears to work without issue. I haven't actually tested the Github Action yet, but I don't see any reason why it shouldn't work, given it also seems to be based on Ubuntu Latest. 

# TL;DR
- Change all instances of SEDOPTION, regardless of platform, to a bash index that gets expanded
- Fixes MacOS errors that generate /x27 (quote) named files should fix #409

I hope this is helpful and happy to work on any tweaks required. Thank you very much for your excellent template and the regular updates to it. It's a huge boon in my work life.

EDIT: Force-pushed to correct a syntax error.