### PR TITLE
Refactor font loading checks in eisvogel-added.latex

### DIFF
--- a/template-multi-file/eisvogel-added.latex
+++ b/template-multi-file/eisvogel-added.latex
@@ -46,7 +46,8 @@ $endif$
 \item\relax\color{blockquote-text}\ignorespaces}{\unskip\unskip\endlist\end{customblockquote}}
 
 %
-% --- Restored v3.4.0 PDFTeX vs. XeTeX/LuaTeX Engine font loading checks ---
+% Source Sans as the default font family
+% Source Code Pro for monospace text
 %
 \ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
   $if(fontfamily)$

--- a/template-multi-file/eisvogel-added.latex
+++ b/template-multi-file/eisvogel-added.latex
@@ -45,19 +45,22 @@ $endif$
 \renewenvironment{quote}{\begin{customblockquote}\list{}{\rightmargin=0em\leftmargin=0em}%
 \item\relax\color{blockquote-text}\ignorespaces}{\unskip\unskip\endlist\end{customblockquote}}
 
-$if(fontfamily)$
-$else$
 %
-% Source Sans as the default font family
-% Source Code Pro for monospace text
+% --- Restored v3.4.0 PDFTeX vs. XeTeX/LuaTeX Engine font loading checks ---
 %
-% 'default' option sets the default
-% font family to Source Sans, not \sfdefault.
-%
-%
-\usepackage[default]{sourcesans}
-\usepackage{sourcecodepro}
-$endif$
+\ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
+  $if(fontfamily)$
+  $else$
+  \usepackage[default]{sourcesans}
+  \usepackage{sourcecodepro}
+  $endif$
+\else % if not pdftex (e.g. lualatex)
+  $if(mainfont)$
+  $else$
+  \usepackage[default]{sourcesans}
+  \usepackage{sourcecodepro}
+  $endif$
+\fi
 
 %
 % heading color


### PR DESCRIPTION
# Updated font loading checks for PDFTeX and XeTeX/LuaTeX engines.

## Description
This PR resolves a regression introduced in version 3.5.0 where `\usepackage[default]{sourcesans}` is loaded unconditionally if the `$fontfamily$` variable is not set. 

By removing the engine and `$mainfont$` conditional check that was present in version 3.4.0, any custom `mainfont` configured via XeLaTeX or LuaLaTeX gets overridden by `sourcesans` (because the package is loaded with the `[default]` option, forcing `\familydefault` to `\sfdefault`). In addition, if a user attempts to load `sourcesans` or `sourcesanspro` in their own `header-includes`, this duplicate loading triggers an `Option clash for package sourcesans` compilation error.

This change restores the v3.4.0 conditional checks to skip loading the default `sourcesans` package when compiling with XeLaTeX/LuaLaTeX and a custom `$mainfont$` is defined.

## Changes Made
- Wrapped the default font loading block for `sourcesans` and `sourcecodepro` in an engine-check conditional block (`\ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0`).
- Ensured that under XeTeX/LuaTeX, `sourcesans` is only loaded if a custom `$mainfont$` is **not** set.

```latex
% --- Restore engine checks to prevent overriding mainfont ---
\ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
  $if(fontfamily)$
  $else$
  \usepackage[default]{sourcesans}
  \usepackage{sourcecodepro}
  $endif$
\else % if not pdftex (e.g. lualatex/xelatex)
  $if(mainfont)$
  $else$
  \usepackage[default]{sourcesans}
  \usepackage{sourcecodepro}
  $endif$
\fi
